### PR TITLE
Allow overlapping impls for marker traits in the coherence rules

### DIFF
--- a/chalk-parse/src/ast.rs
+++ b/chalk-parse/src/ast.rs
@@ -36,7 +36,12 @@ pub struct TraitDefn {
     pub parameter_kinds: Vec<ParameterKind>,
     pub where_clauses: Vec<WhereClause>,
     pub assoc_ty_defns: Vec<AssocTyDefn>,
+    pub flags: TraitFlags,
+}
+
+pub struct TraitFlags {
     pub auto: bool,
+    pub marker: bool,
 }
 
 pub struct AssocTyDefn {

--- a/chalk-parse/src/parser.lalrpop
+++ b/chalk-parse/src/parser.lalrpop
@@ -49,16 +49,20 @@ StructDefn: StructDefn = {
 };
 
 AutoKeyword: () = "#" "[" "auto" "]";
+MarkerKeyword: () = "#" "[" "marker" "]";
 
 TraitDefn: TraitDefn = {
-    <auto:AutoKeyword?> "trait" <n:Id><p:Angle<ParameterKind>> <w:WhereClauses> "{"
+    <auto:AutoKeyword?> <marker:MarkerKeyword?> "trait" <n:Id><p:Angle<ParameterKind>> <w:WhereClauses> "{"
         <a:AssocTyDefn*> "}" =>
     TraitDefn {
         name: n,
         parameter_kinds: p,
         where_clauses: w,
         assoc_ty_defns: a,
-        auto: auto.is_some(),
+        flags: TraitFlags {
+            auto: auto.is_some(),
+            marker: marker.is_some(),
+        },
     }
 };
 

--- a/src/coherence/solve.rs
+++ b/src/coherence/solve.rs
@@ -15,8 +15,13 @@ impl Program {
             solver::get_overflow_depth()
         );
 
-        // Create a vector of references to impl datums, sorted by trait ref
-        let impl_data = self.impl_data.iter().sorted_by(|&(_, lhs), &(_, rhs)| {
+        // Create a vector of references to impl datums, sorted by trait ref.
+        let impl_data = self.impl_data.iter().filter(|&(_, impl_datum)| {
+            // Ignore impls for marker traits as they are allowed to overlap.
+            let trait_id = impl_datum.binders.value.trait_ref.trait_ref().trait_id;
+            let trait_datum = &self.trait_data[&trait_id];
+            !trait_datum.binders.value.flags.marker
+        }).sorted_by(|&(_, lhs), &(_, rhs)| {
             lhs.binders.value.trait_ref.trait_ref().trait_id.cmp(&rhs.binders.value.trait_ref.trait_ref().trait_id)
         });
 

--- a/src/ir/mod.rs
+++ b/src/ir/mod.rs
@@ -244,7 +244,13 @@ pub struct TraitDatum {
 pub struct TraitDatumBound {
     pub trait_ref: TraitRef,
     pub where_clauses: Vec<DomainGoal>,
+    pub flags: TraitFlags,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct TraitFlags {
     pub auto: bool,
+    pub marker: bool,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
@@ -582,7 +588,7 @@ impl FullyReducedGoal {
                 ..
         }) = *self {
             let trait_datum = &program.trait_data[&tr.trait_id];
-            return trait_datum.binders.value.auto;
+            return trait_datum.binders.value.flags.auto;
         }
 
         false

--- a/src/lower/default.rs
+++ b/src/lower/default.rs
@@ -5,7 +5,7 @@ use cast::Cast;
 impl Program {
     pub(super) fn add_default_impls(&mut self) {
         // For each auto trait `MyAutoTrait` and for each struct/type `MyStruct`
-        for auto_trait in self.trait_data.values().filter(|t| t.binders.value.auto) {
+        for auto_trait in self.trait_data.values().filter(|t| t.binders.value.flags.auto) {
             for struct_datum in self.struct_data.values() {
 
                 // `MyStruct: MyAutoTrait`

--- a/src/lower/mod.rs
+++ b/src/lower/mod.rs
@@ -136,7 +136,7 @@ impl LowerProgram for Program {
         let mut associated_ty_infos = HashMap::new();
         for (item, &item_id) in self.items.iter().zip(&item_ids) {
             if let Item::TraitDefn(ref d) = *item {
-                if d.auto && !d.assoc_ty_defns.is_empty() {
+                if d.flags.auto && !d.assoc_ty_defns.is_empty() {
                     bail!("auto trait cannot define associated types");
                 }
                 for defn in &d.assoc_ty_defns {
@@ -806,7 +806,7 @@ impl LowerTrait for TraitDefn {
                 parameters: self.parameter_refs(),
             };
 
-            if self.auto {
+            if self.flags.auto {
                 if trait_ref.parameters.len() > 1 {
                     bail!("auto trait cannot have parameters");
                 }
@@ -818,7 +818,10 @@ impl LowerTrait for TraitDefn {
             Ok(ir::TraitDatumBound {
                 trait_ref: trait_ref,
                 where_clauses: self.lower_where_clauses(env)?,
-                auto: self.auto,
+                flags: ir::TraitFlags {
+                    auto: self.flags.auto,
+                    marker: self.flags.marker,
+                },
             })
         })?;
 

--- a/src/solve/test.rs
+++ b/src/solve/test.rs
@@ -1834,14 +1834,11 @@ fn partial_overlap_2() {
     }
 }
 
-// FIXME: This test currently panics because overlapping
-// impls for marker traits are currently not supported
 #[test]
-#[should_panic(expected = "OverlappingImpls(\"Marker\")")]
 fn partial_overlap_3() {
     test! {
         program {
-            trait Marker {}
+            #[marker] trait Marker {}
             trait Foo {}
             trait Bar {}
 


### PR DESCRIPTION
This introduces the explicit `#[marker]` attribute for marker traits, to allow overlapping impls for marker traits in coherence.

Fixes #62.

Marked WIP because of these questions/comments:
- in parsing, should we ensure `#[auto]` and `#[marker]` can or can't be used at the same time ? or that marker traits are "correct" eg have zero items ?
- I added the `#[marker]` attribute to the solver tests with traits named `Marker` but should we mark others as most of the tests do use marker traits ? or maybe only to the tests *requiring* it, ie `partial_overlap_3`
- this also introduces the requested `TraitFlags` struct but only on the ast side, with bools in  `ir::TraitDatumBound` — is that what was expected or did the instruction mean to also add a similar struct to the ir side ?