### PR TITLE
Unify treatment of types and parameters

### DIFF
--- a/src/cast.rs
+++ b/src/cast.rs
@@ -137,6 +137,18 @@ impl Cast<Ty> for ApplicationTy {
     }
 }
 
+impl Cast<Parameter> for Ty {
+    fn cast(self) -> Parameter {
+        ParameterKind::Ty(self)
+    }
+}
+
+impl Cast<Parameter> for Lifetime {
+    fn cast(self) -> Parameter {
+        ParameterKind::Lifetime(self)
+    }
+}
+
 macro_rules! map_impl {
     (impl[$($t:tt)*] Cast<$b:ty> for $a:ty) => {
         impl<$($t)*> Cast<$b> for $a {
@@ -171,18 +183,6 @@ impl<T, U> Cast<Vec<U>> for Vec<T>
 {
     fn cast(self) -> Vec<U> {
         self.into_iter().casted().collect()
-    }
-}
-
-impl Cast<Parameter> for Ty {
-    fn cast(self) -> Parameter {
-        ParameterKind::Ty(self)
-    }
-}
-
-impl Cast<Parameter> for Lifetime {
-    fn cast(self) -> Parameter {
-        ParameterKind::Lifetime(self)
     }
 }
 

--- a/src/ir/debug.rs
+++ b/src/ir/debug.rs
@@ -280,24 +280,14 @@ impl Display for Substitution {
     fn fmt(&self, f: &mut Formatter) -> Result<(), Error> {
         let mut first = true;
 
-        for (tv, ty) in &self.tys {
+        for (var, value) in &self.parameters {
             if first {
                 first = false;
             } else {
                 write!(f, ", ")?;
             }
 
-            write!(f, "{:?} := {:?}", tv, ty)?;
-        }
-
-        for (lv, lt) in &self.lifetimes {
-            if first {
-                first = false;
-            } else {
-                write!(f, ", ")?;
-            }
-
-            write!(f, "{:?} := {:?}", lv, lt)?;
+            write!(f, "{:?} := {:?}", var, value)?;
         }
 
         Ok(())

--- a/src/solve/fulfill.rs
+++ b/src/solve/fulfill.rs
@@ -3,7 +3,7 @@ use cast::Caster;
 use errors::*;
 use fold::Fold;
 use solve::infer::{InferenceTable, UnificationResult, ParameterInferenceVariable};
-use solve::infer::{TyInferenceVariable, LifetimeInferenceVariable};
+use solve::infer::InferenceVariable;
 use solve::solver::Solver;
 use std::collections::HashSet;
 use std::fmt::Debug;
@@ -205,16 +205,6 @@ impl<'s> Fulfill<'s> {
         }
     }
 
-    /// Provide all of the type inference variables created so far; used for REPL/debugging.
-    pub fn ty_vars(&self) -> &[TyInferenceVariable] {
-        self.infer.ty_vars()
-    }
-
-    /// Provide all of the type inference variables created so far; used for REPL/debugging.
-    pub fn lifetime_vars(&self) -> &[LifetimeInferenceVariable] {
-        self.infer.lifetime_vars()
-    }
-
     /// Apply the subsitution `subst` to all the variables of `free_vars`
     /// (understood in deBruijn style), and add any lifetime constraints.
     fn apply_solution(&mut self,
@@ -237,14 +227,14 @@ impl<'s> Fulfill<'s> {
                 ParameterKind::Ty(ty) => {
                     // Should always be `Some(..)` unless we applied coinductive semantics
                     // somewhere and hence returned an empty substitution.
-                    if let Some(new_ty) = subst.tys.get(&TyInferenceVariable::from_depth(i)) {
+                    if let Some(new_ty) = subst.tys.get(&InferenceVariable::from_depth(i)) {
                         self.unify(empty_env, &ty.to_ty(), &new_ty)
                             .expect("apply_solution failed to substitute");
                     }
                 }
                 ParameterKind::Lifetime(lt) => {
                     // Same as above.
-                    if let Some(new_lt) = subst.lifetimes.get(&LifetimeInferenceVariable::from_depth(i)) {
+                    if let Some(new_lt) = subst.lifetimes.get(&InferenceVariable::from_depth(i)) {
                         self.unify(empty_env, &lt.to_lifetime(), &new_lt)
                             .expect("apply_solution failed to substitute");
                     }

--- a/src/solve/infer/canonicalize.rs
+++ b/src/solve/infer/canonicalize.rs
@@ -3,9 +3,7 @@ use fold::{DefaultTypeFolder, ExistentialFolder, Fold, UniversalFolder};
 use ir::*;
 use std::cmp::max;
 
-use super::{InferenceTable, TyInferenceVariable, LifetimeInferenceVariable,
-            ParameterInferenceVariable};
-use super::var::InferenceValue;
+use super::{InferenceTable, InferenceVariable, ParameterInferenceVariable};
 
 impl InferenceTable {
     /// Given a value `value` with variables in it, replaces those variables
@@ -70,10 +68,10 @@ impl<T> Canonicalized<T> {
         for (i, free_var) in self.free_vars.iter().enumerate() {
             match free_var {
                 ParameterKind::Ty(v) => {
-                    subst.tys.insert(TyInferenceVariable::from_depth(i), v.to_ty());
+                    subst.tys.insert(InferenceVariable::from_depth(i), v.to_ty());
                 }
                 ParameterKind::Lifetime(l) => {
-                    subst.lifetimes.insert(LifetimeInferenceVariable::from_depth(i), l.to_lifetime());
+                    subst.lifetimes.insert(InferenceVariable::from_depth(i), l.to_lifetime());
                 }
             }
         }
@@ -91,23 +89,9 @@ struct Canonicalizer<'q> {
 impl<'q> Canonicalizer<'q> {
     fn into_binders(self) -> Vec<ParameterKind<UniverseIndex>> {
         let Canonicalizer { table, free_vars, max_universe: _ } = self;
-        free_vars.into_iter()
-            .map(|p_v| match p_v {
-                     ParameterKind::Ty(v) => {
-                         debug_assert!(table.ty_unify.find(v) == v);
-                         match table.ty_unify.probe_value(v) {
-                             InferenceValue::Unbound(ui) => ParameterKind::Ty(ui),
-                             InferenceValue::Bound(_) => panic!("free var now bound"),
-                         }
-                     }
-
-                     ParameterKind::Lifetime(v) => {
-                         match table.lifetime_unify.probe_value(v) {
-                             InferenceValue::Unbound(ui) => ParameterKind::Lifetime(ui),
-                             InferenceValue::Bound(_) => panic!("free var now bound"),
-                         }
-                     }
-                 })
+        free_vars
+            .into_iter()
+            .map(|p_v| p_v.map(|v| table.universe_of_unbound_var(v)))
             .collect()
     }
 
@@ -140,8 +124,8 @@ impl<'q> UniversalFolder for Canonicalizer<'q> {
 impl<'q> ExistentialFolder for Canonicalizer<'q> {
     fn fold_free_existential_ty(&mut self, depth: usize, binders: usize) -> Result<Ty> {
         debug_heading!("fold_free_existential_ty(depth={:?}, binders={:?})", depth, binders);
-        let var = TyInferenceVariable::from_depth(depth);
-        match self.table.probe_var(var) {
+        let var = InferenceVariable::from_depth(depth);
+        match self.table.probe_ty_var(var) {
             Some(ty) => {
                 debug!("bound to {:?}", ty);
                 Ok(ty.fold_with(self, 0)?.up_shift(binders))
@@ -151,27 +135,27 @@ impl<'q> ExistentialFolder for Canonicalizer<'q> {
                 // canonical index `root_var` in the union-find table,
                 // and then map `root_var` to a fresh index that is
                 // unique to this quantification.
-                let free_var = ParameterKind::Ty(self.table.ty_unify.find(var));
+                let free_var = ParameterKind::Ty(self.table.unify.find(var));
                 let position = self.add(free_var);
                 debug!("not yet unified: position={:?}", position);
-                Ok(TyInferenceVariable::from_depth(position + binders).to_ty())
+                Ok(InferenceVariable::from_depth(position + binders).to_ty())
             }
         }
     }
 
     fn fold_free_existential_lifetime(&mut self, depth: usize, binders: usize) -> Result<Lifetime> {
         debug_heading!("fold_free_existential_lifetime(depth={:?}, binders={:?})", depth, binders);
-        let var = LifetimeInferenceVariable::from_depth(depth);
+        let var = InferenceVariable::from_depth(depth);
         match self.table.probe_lifetime_var(var) {
             Some(l) => {
                 debug!("bound to {:?}", l);
                 Ok(l.fold_with(self, 0)?.up_shift(binders))
             }
             None => {
-                let free_var = ParameterKind::Lifetime(self.table.lifetime_unify.find(var));
+                let free_var = ParameterKind::Lifetime(self.table.unify.find(var));
                 let position = self.add(free_var);
                 debug!("not yet unified: position={:?}", position);
-                Ok(LifetimeInferenceVariable::from_depth(position + binders).to_lifetime())
+                Ok(InferenceVariable::from_depth(position + binders).to_lifetime())
             }
         }
     }

--- a/src/solve/infer/canonicalize.rs
+++ b/src/solve/infer/canonicalize.rs
@@ -66,14 +66,7 @@ impl<T> Canonicalized<T> {
     pub fn into_quantified_and_subst(self) -> (Canonical<T>, Substitution) {
         let mut subst = Substitution::empty();
         for (i, free_var) in self.free_vars.iter().enumerate() {
-            match free_var {
-                ParameterKind::Ty(v) => {
-                    subst.tys.insert(InferenceVariable::from_depth(i), v.to_ty());
-                }
-                ParameterKind::Lifetime(l) => {
-                    subst.lifetimes.insert(InferenceVariable::from_depth(i), l.to_lifetime());
-                }
-            }
+            subst.insert(InferenceVariable::from_depth(i), free_var.to_parameter());
         }
 
         (self.quantified, subst)

--- a/src/solve/infer/instantiate.rs
+++ b/src/solve/infer/instantiate.rs
@@ -13,7 +13,7 @@ impl InferenceTable {
     {
         debug!("instantiate(arg={:?})", arg);
         let vars: Vec<_> = universes.into_iter()
-            .map(|u| self.new_parameter_variable(u))
+            .map(|u| u.map(|u| self.new_variable(u)))
             .collect();
         debug!("instantiate: vars={:?}", vars);
         let mut instantiator = Instantiator { vars };
@@ -32,11 +32,11 @@ impl InferenceTable {
         for (i, kind) in binders.iter().enumerate() {
             match *kind {
                 ParameterKind::Ty(ui) => {
-                    tys.insert(TyInferenceVariable::from_depth(i), self.new_variable(ui).to_ty());
+                    tys.insert(InferenceVariable::from_depth(i), self.new_variable(ui).to_ty());
                 }
                 ParameterKind::Lifetime(ui) => {
-                    lifetimes.insert(LifetimeInferenceVariable::from_depth(i),
-                                     self.new_lifetime_variable(ui).to_lifetime());
+                    lifetimes.insert(InferenceVariable::from_depth(i),
+                                     self.new_variable(ui).to_lifetime());
                 }
             }
         }

--- a/src/solve/infer/instantiate.rs
+++ b/src/solve/infer/instantiate.rs
@@ -1,5 +1,4 @@
 use fold::*;
-use std::collections::BTreeMap;
 use std::fmt::Debug;
 
 use super::*;
@@ -26,22 +25,14 @@ impl InferenceTable {
     /// C, which would be equivalent to
     /// `self.instantiate_canonical(v)`.
     pub fn fresh_subst(&mut self, binders: &[ParameterKind<UniverseIndex>]) -> Substitution {
-        let mut tys = BTreeMap::new();
-        let mut lifetimes = BTreeMap::new();
+        let mut subst = Substitution::empty();
 
         for (i, kind) in binders.iter().enumerate() {
-            match *kind {
-                ParameterKind::Ty(ui) => {
-                    tys.insert(InferenceVariable::from_depth(i), self.new_variable(ui).to_ty());
-                }
-                ParameterKind::Lifetime(ui) => {
-                    lifetimes.insert(InferenceVariable::from_depth(i),
-                                     self.new_variable(ui).to_lifetime());
-                }
-            }
+            let param_infer_var = kind.map(|ui| self.new_variable(ui));
+            subst.insert(InferenceVariable::from_depth(i), param_infer_var.to_parameter());
         }
 
-        Substitution { tys, lifetimes }
+        subst
     }
 
     /// Variant on `instantiate` that takes a `Canonical<T>`.
@@ -93,7 +84,7 @@ impl DefaultTypeFolder for Instantiator { }
 impl ExistentialFolder for Instantiator {
     fn fold_free_existential_ty(&mut self, depth: usize, binders: usize) -> Result<Ty> {
         if depth < self.vars.len() {
-            Ok(self.vars[depth].as_ref().ty().unwrap().to_ty().up_shift(binders))
+            Ok(self.vars[depth].assert_ty_ref().to_ty().up_shift(binders))
         } else {
             Ok(Ty::Var(depth + binders - self.vars.len())) // see comment above
         }
@@ -101,7 +92,7 @@ impl ExistentialFolder for Instantiator {
 
     fn fold_free_existential_lifetime(&mut self, depth: usize, binders: usize) -> Result<Lifetime> {
         if depth < self.vars.len() {
-            Ok(self.vars[depth].as_ref().lifetime().unwrap().to_lifetime().up_shift(binders))
+            Ok(self.vars[depth].assert_lifetime_ref().to_lifetime().up_shift(binders))
         } else {
             Ok(Lifetime::Var(depth + binders - self.vars.len())) // see comment above
         }

--- a/src/solve/infer/invert.rs
+++ b/src/solve/infer/invert.rs
@@ -3,7 +3,7 @@ use fold::{DefaultTypeFolder, ExistentialFolder, Fold, UniversalFolder};
 use ir::*;
 use std::collections::HashMap;
 
-use super::{InferenceTable, TyInferenceVariable, LifetimeInferenceVariable};
+use super::{InferenceTable, InferenceVariable};
 use super::canonicalize::Canonicalized;
 
 impl InferenceTable {
@@ -104,8 +104,8 @@ impl InferenceTable {
 
 struct Inverter<'q> {
     table: &'q mut InferenceTable,
-    inverted_ty: HashMap<UniverseIndex, TyInferenceVariable>,
-    inverted_lifetime: HashMap<UniverseIndex, LifetimeInferenceVariable>,
+    inverted_ty: HashMap<UniverseIndex, InferenceVariable>,
+    inverted_lifetime: HashMap<UniverseIndex, InferenceVariable>,
 }
 
 impl<'q> Inverter<'q> {
@@ -130,7 +130,7 @@ impl<'q> UniversalFolder for Inverter<'q> {
         let table = &mut self.table;
         Ok(self.inverted_lifetime
            .entry(universe)
-           .or_insert_with(|| table.new_lifetime_variable(universe))
+           .or_insert_with(|| table.new_variable(universe))
            .to_lifetime()
            .up_shift(binders))
     }

--- a/src/solve/infer/mod.rs
+++ b/src/solve/infer/mod.rs
@@ -12,84 +12,71 @@ mod var;
 
 pub use self::canonicalize::Canonicalized;
 pub use self::unify::UnificationResult;
-pub use self::var::{TyInferenceVariable, LifetimeInferenceVariable};
+pub use self::var::InferenceVariable;
 use self::var::*;
 
 #[derive(Clone)]
 pub struct InferenceTable {
-    ty_unify: ena::UnificationTable<TyInferenceVariable>,
-    ty_vars: Vec<TyInferenceVariable>,
-    lifetime_unify: ena::UnificationTable<LifetimeInferenceVariable>,
-    lifetime_vars: Vec<LifetimeInferenceVariable>,
+    unify: ena::UnificationTable<InferenceVariable>,
+    vars: Vec<InferenceVariable>,
 }
 
 pub struct InferenceSnapshot {
-    ty_unify_snapshot: ena::Snapshot<TyInferenceVariable>,
-    ty_vars: Vec<TyInferenceVariable>,
-    lifetime_unify_snapshot: ena::Snapshot<LifetimeInferenceVariable>,
-    lifetime_vars: Vec<LifetimeInferenceVariable>,
+    unify_snapshot: ena::Snapshot<InferenceVariable>,
+    vars: Vec<InferenceVariable>,
 }
 
-pub type ParameterInferenceVariable = ParameterKind<TyInferenceVariable, LifetimeInferenceVariable>;
+pub type ParameterInferenceVariable = ParameterKind<InferenceVariable>;
 
 impl InferenceTable {
+    /// Create an empty inference table with no variables.
     pub fn new() -> Self {
         InferenceTable {
-            ty_unify: ena::UnificationTable::new(),
-            ty_vars: vec![],
-            lifetime_unify: ena::UnificationTable::new(),
-            lifetime_vars: vec![],
+            unify: ena::UnificationTable::new(),
+            vars: vec![],
         }
     }
 
-    pub fn new_variable(&mut self, ui: UniverseIndex) -> TyInferenceVariable {
-        let var = self.ty_unify.new_key(InferenceValue::Unbound(ui));
-        self.ty_vars.push(var);
+    /// Creates a new inference variable and returns its index. The
+    /// kind of the variable should be known by the caller, but is not
+    /// tracked directly by the inference table.
+    pub fn new_variable(&mut self, ui: UniverseIndex) -> InferenceVariable {
+        let var = self.unify.new_key(InferenceValue::Unbound(ui));
+        self.vars.push(var);
         var
     }
 
-    pub fn new_lifetime_variable(&mut self, ui: UniverseIndex) -> LifetimeInferenceVariable {
-        let var = self.lifetime_unify.new_key(InferenceValue::Unbound(ui));
-        self.lifetime_vars.push(var);
-        var
-    }
-
-    pub fn new_parameter_variable(&mut self, ui: ParameterKind<UniverseIndex>)
-                                  -> ParameterInferenceVariable {
-        match ui {
-            ParameterKind::Ty(ui) => ParameterKind::Ty(self.new_variable(ui)),
-            ParameterKind::Lifetime(ui) => ParameterKind::Lifetime(self.new_lifetime_variable(ui)),
-        }
-    }
-
-    pub fn ty_vars(&self) -> &[TyInferenceVariable] {
-        &self.ty_vars
-    }
-
-    pub fn lifetime_vars(&self) -> &[LifetimeInferenceVariable] {
-        &self.lifetime_vars
-    }
-
+    /// Takes a "snapshot" of the current state of the inference
+    /// table.  Later, you must invoke either `rollback_to` or
+    /// `commit` with that snapshot.  Snapshots can be nested, but you
+    /// must respect a stack discipline (i.e., rollback or commit
+    /// snapshots in reverse order of that with which they were
+    /// created).
     pub fn snapshot(&mut self) -> InferenceSnapshot {
-        let ty_unify_snapshot = self.ty_unify.snapshot();
-        let lifetime_unify_snapshot = self.lifetime_unify.snapshot();
-        let ty_vars = self.ty_vars.clone();
-        let lifetime_vars = self.lifetime_vars.clone();
-        InferenceSnapshot { ty_unify_snapshot, lifetime_unify_snapshot, ty_vars, lifetime_vars }
+        let unify_snapshot = self.unify.snapshot();
+        let vars = self.vars.clone();
+        InferenceSnapshot { unify_snapshot, vars }
     }
 
+    /// Restore the table to the state it had when the snapshot was taken.
     pub fn rollback_to(&mut self, snapshot: InferenceSnapshot) {
-        self.ty_unify.rollback_to(snapshot.ty_unify_snapshot);
-        self.lifetime_unify.rollback_to(snapshot.lifetime_unify_snapshot);
-        self.ty_vars = snapshot.ty_vars;
-        self.lifetime_vars = snapshot.lifetime_vars;
+        self.unify.rollback_to(snapshot.unify_snapshot);
+        self.vars = snapshot.vars;
     }
 
+    /// Make permanent the changes made since the snapshot was taken.
     pub fn commit(&mut self, snapshot: InferenceSnapshot) {
-        self.ty_unify.commit(snapshot.ty_unify_snapshot);
-        self.lifetime_unify.commit(snapshot.lifetime_unify_snapshot);
+        self.unify.commit(snapshot.unify_snapshot);
     }
 
+    /// This helper function creates a snapshot and then execues `op`;
+    /// if `op` returns `Ok(v)`, then the snapshot is committed and
+    /// `Ok(v)` is returned.  If `op` returns `Err(e)`, then the
+    /// changes are rolled back and `Err(e)` is propagated.
+    ///
+    /// This is commonly used to perform a series of smaller changes,
+    /// some of which may be fallible; the result is that either all
+    /// the changes take effect, or none.
     pub fn commit_if_ok<F, R>(&mut self, op: F) -> Result<R>
         where F: FnOnce(&mut Self) -> Result<R>
     {
@@ -119,33 +106,73 @@ impl InferenceTable {
                 if depth < binders {
                     None // bound variable, not an inference var
                 } else {
-                    let var = TyInferenceVariable::from_depth(depth - binders);
-                    match self.ty_unify.probe_value(var) {
+                    let var = InferenceVariable::from_depth(depth - binders);
+                    match self.unify.probe_value(var) {
                         InferenceValue::Unbound(_) => None,
-                        InferenceValue::Bound(ref val) => Some(val.up_shift(binders)),
+                        InferenceValue::Bound(ref val) => {
+                            let ty = val.as_ref().ty().unwrap();
+                            Some(ty.up_shift(binders))
+                        }
                     }
                 }
             })
     }
 
+    /// If `leaf` represents an inference variable `X`, and `X` is bound,
+    /// returns `Some(v)` where `v` is the value to which `X` is bound.
     fn normalize_lifetime(&mut self, leaf: &Lifetime) -> Option<Lifetime> {
         match *leaf {
-            Lifetime::Var(v) => self.probe_lifetime_var(LifetimeInferenceVariable::from_depth(v)),
+            Lifetime::Var(v) => self.probe_lifetime_var(InferenceVariable::from_depth(v)),
             Lifetime::ForAll(_) => None,
         }
     }
 
-    pub fn probe_var(&mut self, var: TyInferenceVariable) -> Option<Ty> {
-        match self.ty_unify.probe_value(var) {
+    /// Finds the type to which `var` is bound, returning `None` if it is not yet
+    /// bound.
+    ///
+    /// # Panics
+    ///
+    /// This method is only valid for inference variables of kind
+    /// type. If this variable is of a different kind, then the
+    /// function may panic.
+    fn probe_ty_var(&mut self, var: InferenceVariable) -> Option<Ty> {
+        match self.unify.probe_value(var) {
             InferenceValue::Unbound(_) => None,
-            InferenceValue::Bound(ref val) => Some(val.clone()),
+            InferenceValue::Bound(ref val) => Some(val.as_ref().ty().unwrap().clone()),
         }
     }
 
-    pub fn probe_lifetime_var(&mut self, var: LifetimeInferenceVariable) -> Option<Lifetime> {
-        match self.lifetime_unify.probe_value(var) {
+    /// Finds the lifetime to which `var` is bound, returning `None` if it is not yet
+    /// bound.
+    ///
+    /// # Panics
+    ///
+    /// This method is only valid for inference variables of kind
+    /// lifetime. If this variable is of a different kind, then the function may panic.
+    fn probe_lifetime_var(&mut self, var: InferenceVariable) -> Option<Lifetime> {
+        match self.unify.probe_value(var) {
             InferenceValue::Unbound(_) => None,
-            InferenceValue::Bound(val) => Some(val.clone()),
+            InferenceValue::Bound(ref val) => Some(val.as_ref().lifetime().unwrap().clone()),
+        }
+    }
+
+    /// True if the given inference variable is bound to a value.
+    pub fn var_is_bound(&mut self, var: InferenceVariable) -> bool {
+        match self.unify.probe_value(var) {
+            InferenceValue::Unbound(_) => false,
+            InferenceValue::Bound(_) => true,
+        }
+    }
+
+    /// Given an unbound variable, returns its universe.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the variable is bound.
+    fn universe_of_unbound_var(&mut self, var: InferenceVariable) -> UniverseIndex {
+        match self.unify.probe_value(var) {
+            InferenceValue::Unbound(ui) => ui,
+            InferenceValue::Bound(_) => panic!("var_universe invoked on bound variable")
         }
     }
 }
@@ -165,8 +192,8 @@ impl Ty {
     /// `self` is known not to appear inside of any binders, since
     /// otherwise the depth would have be adjusted to account for
     /// those binders.
-    pub fn inference_var(&self) -> Option<TyInferenceVariable> {
-        self.var().map(TyInferenceVariable::from_depth)
+    pub fn inference_var(&self) -> Option<InferenceVariable> {
+        self.var().map(InferenceVariable::from_depth)
     }
 }
 
@@ -185,8 +212,8 @@ impl Lifetime {
     /// `self` is known not to appear inside of any binders, since
     /// otherwise the depth would have be adjusted to account for
     /// those binders.
-    pub fn inference_var(&self) -> Option<LifetimeInferenceVariable> {
-        self.var().map(LifetimeInferenceVariable::from_depth)
+    pub fn inference_var(&self) -> Option<InferenceVariable> {
+        self.var().map(InferenceVariable::from_depth)
     }
 }
 
@@ -196,7 +223,7 @@ impl Substitution {
     pub fn is_trivial_within(&self, in_infer: &mut InferenceTable) -> bool {
         for ty in self.tys.values() {
             if let Some(var) = ty.inference_var() {
-                if in_infer.probe_var(var).is_some() {
+                if in_infer.var_is_bound(var) {
                     return false;
                 }
             }
@@ -204,7 +231,7 @@ impl Substitution {
 
         for lt in self.lifetimes.values() {
             if let Some(var) = lt.inference_var() {
-                if in_infer.probe_lifetime_var(var).is_some() {
+                if in_infer.var_is_bound(var) {
                     return false;
                 }
             }

--- a/src/solve/infer/mod.rs
+++ b/src/solve/infer/mod.rs
@@ -221,22 +221,35 @@ impl Substitution {
     /// Check whether this substitution is the identity substitution in the
     /// given inference context.
     pub fn is_trivial_within(&self, in_infer: &mut InferenceTable) -> bool {
-        for ty in self.tys.values() {
-            if let Some(var) = ty.inference_var() {
-                if in_infer.var_is_bound(var) {
-                    return false;
+        for value in self.parameters.values() {
+            match value {
+                ParameterKind::Ty(ty) => {
+                    if let Some(var) = ty.inference_var() {
+                        if in_infer.var_is_bound(var) {
+                            return false;
+                        }
+                    }
                 }
-            }
-        }
 
-        for lt in self.lifetimes.values() {
-            if let Some(var) = lt.inference_var() {
-                if in_infer.var_is_bound(var) {
-                    return false;
+                ParameterKind::Lifetime(lifetime) => {
+                    if let Some(var) = lifetime.inference_var() {
+                        if in_infer.var_is_bound(var) {
+                            return false;
+                        }
+                    }
                 }
             }
         }
 
         true
+    }
+}
+
+impl ParameterInferenceVariable {
+    pub fn to_parameter(self) -> Parameter {
+        match self {
+            ParameterKind::Ty(v) => ParameterKind::Ty(v.to_ty()),
+            ParameterKind::Lifetime(v) => ParameterKind::Lifetime(v.to_lifetime()),
+        }
     }
 }

--- a/src/solve/infer/normalize_deep.rs
+++ b/src/solve/infer/normalize_deep.rs
@@ -2,7 +2,7 @@ use errors::*;
 use fold::{DefaultTypeFolder, ExistentialFolder, Fold, IdentityUniversalFolder};
 use ir::*;
 
-use super::{InferenceTable, TyInferenceVariable, LifetimeInferenceVariable};
+use super::{InferenceTable, InferenceVariable};
 
 impl InferenceTable {
     /// Given a value `value` with variables in it, replaces those variables
@@ -32,18 +32,18 @@ impl<'table> IdentityUniversalFolder for DeepNormalizer<'table> {
 
 impl<'table> ExistentialFolder for DeepNormalizer<'table> {
     fn fold_free_existential_ty(&mut self, depth: usize, binders: usize) -> Result<Ty> {
-        let var = TyInferenceVariable::from_depth(depth);
-        match self.table.probe_var(var) {
+        let var = InferenceVariable::from_depth(depth);
+        match self.table.probe_ty_var(var) {
             Some(ty) => Ok(ty.fold_with(self, 0)?.up_shift(binders)),
-            None => Ok(TyInferenceVariable::from_depth(depth + binders).to_ty())
+            None => Ok(InferenceVariable::from_depth(depth + binders).to_ty())
         }
     }
 
     fn fold_free_existential_lifetime(&mut self, depth: usize, binders: usize) -> Result<Lifetime> {
-        let var = LifetimeInferenceVariable::from_depth(depth);
+        let var = InferenceVariable::from_depth(depth);
         match self.table.probe_lifetime_var(var) {
             Some(l) => Ok(l.fold_with(self, 0)?.up_shift(binders)),
-            None => Ok(LifetimeInferenceVariable::from_depth(depth + binders).to_lifetime()),
+            None => Ok(InferenceVariable::from_depth(depth + binders).to_lifetime()),
         }
     }
 }

--- a/src/solve/infer/test.rs
+++ b/src/solve/infer/test.rs
@@ -19,8 +19,8 @@ impl<'q> DefaultTypeFolder for Normalizer<'q> {
 impl<'q> ExistentialFolder for Normalizer<'q> {
     fn fold_free_existential_ty(&mut self, depth: usize, binders: usize) -> Result<Ty> {
         assert_eq!(binders, 0);
-        let var = TyInferenceVariable::from_depth(depth);
-        match self.table.probe_var(var) {
+        let var = InferenceVariable::from_depth(depth);
+        match self.table.probe_ty_var(var) {
             Some(ty) => ty.fold_with(self, 0),
             None => Ok(var.to_ty()),
         }
@@ -28,7 +28,7 @@ impl<'q> ExistentialFolder for Normalizer<'q> {
 
     fn fold_free_existential_lifetime(&mut self, depth: usize, binders: usize) -> Result<Lifetime> {
         assert_eq!(binders, 0);
-        Ok(LifetimeInferenceVariable::from_depth(depth).to_lifetime())
+        Ok(InferenceVariable::from_depth(depth).to_lifetime())
     }
 }
 
@@ -150,9 +150,9 @@ const U2: UniverseIndex = UniverseIndex { counter: 2 };
 #[test]
 fn quantify_simple() {
     let mut table = InferenceTable::new();
-    let _ = table.new_parameter_variable(ParameterKind::Ty(U0));
-    let _ = table.new_parameter_variable(ParameterKind::Ty(U1));
-    let _ = table.new_parameter_variable(ParameterKind::Ty(U2));
+    let _ = table.new_variable(U0);
+    let _ = table.new_variable(U1);
+    let _ = table.new_variable(U2);
 
     assert_eq!(
         table.canonicalize(&ty!(apply (item 0) (var 2) (var 1) (var 0))).quantified,
@@ -193,7 +193,7 @@ fn quantify_ty_under_binder() {
     let mut table = InferenceTable::new();
     let v0 = table.new_variable(U0);
     let v1 = table.new_variable(U0);
-    let _r0 = table.new_lifetime_variable(U0);
+    let _r0 = table.new_variable(U0);
 
     // Unify v0 and v1.
     let environment0 = Environment::new();

--- a/src/solve/infer/var.rs
+++ b/src/solve/infer/var.rs
@@ -1,100 +1,100 @@
 use ena::unify::{UnifyKey, UnifyValue};
 use ir::*;
 use std::cmp::min;
-use std::fmt::{self, Debug};
+use std::fmt;
 use std::u32;
 
+/// An inference variable represents an unknown term -- either a type
+/// or a lifetime. The variable itself is just an index into the unification
+/// table; the unification table maps it to an `InferenceValue`.
+///
+/// Inference variables can be in one of two states (represents by the variants
+/// of an `InferenceValue`):
+///
+/// - Unbound(`ui`). In this case, the value of the variable is not yet known. We carry
+///   along a universe index `ui` that tracks the universe in which the variable was
+///   created; this determines what names may appear in the variable's value.
+///   - In this state, we do **not** track the kind of this variable
+///     (i.e., whether it represents a type or a lifetime). There is
+///     no need: if it represents a lifetime, for example, then there
+///     should only ever be constraints that relate it to other
+///     lifetimes, or use it in lifetime position.
+/// - Bound. In this case, the value of the variable is known. We
+///   carry along the value. We discard the universe index in which
+///   the variable was created, since that was only needed to help us
+///   reject illegal values. Once the value of a variable is known, it
+///   can never change.
+///   - The value we actually store for variables is a
+///     `ir::Parameter`, and hence it does carry along the kind of the
+///     variable via the enum variant. However, we should always know
+///     the kind of the variable from context, and hence we typically
+///     "downcast" the resulting variable using
+///     e.g. `value.ty().unwrap()`.
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct TyInferenceVariable {
+pub struct InferenceVariable {
     index: u32,
 }
 
-impl TyInferenceVariable {
-    pub fn from_depth(depth: usize) -> TyInferenceVariable {
+impl InferenceVariable {
+    /// Create an inference variable from a debruijn depth. In terms,
+    /// like the `Ty::Var` variant, we use debruijn indices to refer
+    /// to either index variables or bound variables. Presuming that
+    /// the depth D in the term is greater than the number of
+    /// enclosing binders B, then it refers to an inference variable,
+    /// and the inference variable can be created via
+    /// `InferenceVariable::from_depth(D - B)`.
+    pub fn from_depth(depth: usize) -> InferenceVariable {
         assert!(depth < u32::MAX as usize);
-        TyInferenceVariable { index: depth as u32 }
+        InferenceVariable { index: depth as u32 }
     }
 
-    pub fn from_u32(depth: u32) -> TyInferenceVariable {
-        TyInferenceVariable { index: depth }
-    }
-
-    pub fn to_ty(&self) -> Ty {
+    /// Convert this inference variable into a type. When using this
+    /// method, naturally you should know from context that the kind
+    /// of this inference variable is a type (we can't check it).
+    pub fn to_ty(self) -> Ty {
         Ty::Var(self.index as usize)
     }
 
-    pub fn to_usize(&self) -> usize {
+    /// Convert this inference variable into a lifetime. When using this
+    /// method, naturally you should know from context that the kind
+    /// of this inference variable is a lifetime (we can't check it).
+    pub fn to_lifetime(self) -> Lifetime {
+        Lifetime::Var(self.index as usize)
+    }
+
+    /// Convert this variable to its internal index. Occasionally its
+    /// useful to index into a vector.
+    pub fn to_usize(self) -> usize {
         self.index as usize
     }
 }
 
-impl UnifyKey for TyInferenceVariable {
-    type Value = InferenceValue<Ty>;
+impl UnifyKey for InferenceVariable {
+    type Value = InferenceValue;
 
     fn index(&self) -> u32 {
         self.index
     }
 
     fn from_index(u: u32) -> Self {
-        TyInferenceVariable { index: u }
+        InferenceVariable { index: u }
     }
 
     fn tag() -> &'static str {
-        "TyInferenceVariable"
-    }
-}
-
-#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct LifetimeInferenceVariable {
-    index: u32,
-}
-
-impl LifetimeInferenceVariable {
-    pub fn from_depth(depth: usize) -> LifetimeInferenceVariable {
-        LifetimeInferenceVariable { index: depth as u32 }
-    }
-
-    pub fn to_usize(&self) -> usize {
-        self.index as usize
-    }
-
-    pub fn to_lifetime(&self) -> Lifetime {
-        Lifetime::Var(self.to_usize())
-    }
-}
-
-impl fmt::Debug for LifetimeInferenceVariable {
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        write!(fmt, "'?{}", self.index)
-    }
-}
-
-impl UnifyKey for LifetimeInferenceVariable {
-    type Value = InferenceValue<Lifetime>;
-
-    fn index(&self) -> u32 {
-        self.index
-    }
-
-    fn from_index(u: u32) -> Self {
-        LifetimeInferenceVariable { index: u }
-    }
-
-    fn tag() -> &'static str {
-        "LifetimeInferenceVariable"
+        "InferenceVariable"
     }
 }
 
 /// The value of an inference variable. We start out as `Unbound` with a
 /// universe index; when the inference variable is assigned a value, it becomes
-/// bound and records that value.
+/// bound and records that value. See `InferenceVariable` for more details.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub enum InferenceValue<V: Clone + Debug> {
+pub enum InferenceValue {
     Unbound(UniverseIndex),
-    Bound(V),
+    Bound(Parameter),
 }
 
-impl<V: Clone + Debug> InferenceValue<V> {
+impl InferenceValue {
     pub fn unbound(&self) -> Option<UniverseIndex> {
         match *self {
             InferenceValue::Unbound(ui) => Some(ui),
@@ -103,9 +103,21 @@ impl<V: Clone + Debug> InferenceValue<V> {
     }
 }
 
-impl<V: Clone + Debug> UnifyValue for InferenceValue<V> {
-    fn unify_values(a: &InferenceValue<V>, b: &InferenceValue<V>)
-                    -> Result<InferenceValue<V>, (InferenceValue<V>, InferenceValue<V>)> {
+impl From<Ty> for InferenceValue {
+    fn from(ty: Ty) -> Self {
+        InferenceValue::Bound(ParameterKind::Ty(ty))
+    }
+}
+
+impl From<Lifetime> for InferenceValue {
+    fn from(lifetime: Lifetime) -> Self {
+        InferenceValue::Bound(ParameterKind::Lifetime(lifetime))
+    }
+}
+
+impl UnifyValue for InferenceValue {
+    fn unify_values(a: &InferenceValue, b: &InferenceValue)
+                    -> Result<InferenceValue, (InferenceValue, InferenceValue)> {
         match (a, b) {
             (&InferenceValue::Unbound(ui_a), &InferenceValue::Unbound(ui_b)) => {
                 Ok(InferenceValue::Unbound(min(ui_a, ui_b)))
@@ -121,7 +133,7 @@ impl<V: Clone + Debug> UnifyValue for InferenceValue<V> {
     }
 }
 
-impl fmt::Debug for TyInferenceVariable {
+impl fmt::Debug for InferenceVariable {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> Result<(), fmt::Error> {
         write!(fmt, "?{}", self.index)
     }

--- a/src/solve/slg/aggregate.rs
+++ b/src/solve/slg/aggregate.rs
@@ -261,7 +261,7 @@ impl<'infer> AntiUnifier<'infer> {
 
     fn new_lifetime_variable(&mut self) -> Lifetime {
         self.infer
-            .new_lifetime_variable(self.universe)
+            .new_variable(self.universe)
             .to_lifetime()
     }
 }

--- a/src/solve/slg/test.rs
+++ b/src/solve/slg/test.rs
@@ -80,8 +80,7 @@ fn slg_from_env() {
                         subst: Canonical {
                             value: ConstrainedSubst {
                                 subst: Substitution {
-                                    tys: {},
-                                    lifetimes: {}
+                                    parameters: {}
                                 },
                                 constraints: []
                             },
@@ -117,10 +116,9 @@ fn positive_cycle() {
                         subst: Canonical {
                             value: ConstrainedSubst {
                                 subst: Substitution {
-                                    tys: {
+                                    parameters: {
                                         ?0: i32
-                                    },
-                                    lifetimes: {}
+                                    }
                                 },
                                 constraints: []
                             },
@@ -132,10 +130,9 @@ fn positive_cycle() {
                         subst: Canonical {
                             value: ConstrainedSubst {
                                 subst: Substitution {
-                                    tys: {
+                                    parameters: {
                                         ?0: Vec<i32>
-                                    },
-                                    lifetimes: {}
+                                    }
                                 },
                                 constraints: []
                             },
@@ -147,10 +144,9 @@ fn positive_cycle() {
                         subst: Canonical {
                             value: ConstrainedSubst {
                                 subst: Substitution {
-                                    tys: {
+                                    parameters: {
                                         ?0: Vec<Vec<?0>>
-                                    },
-                                    lifetimes: {}
+                                    }
                                 },
                                 constraints: []
                             },
@@ -164,10 +160,9 @@ fn positive_cycle() {
                         subst: Canonical {
                             value: ConstrainedSubst {
                                 subst: Substitution {
-                                    tys: {
+                                    parameters: {
                                         ?0: Vec<Vec<i32>>
-                                    },
-                                    lifetimes: {}
+                                    }
                                 },
                                 constraints: []
                             },
@@ -231,8 +226,7 @@ fn subgoal_cycle_uninhabited() {
                         subst: Canonical {
                             value: ConstrainedSubst {
                                 subst: Substitution {
-                                    tys: {},
-                                    lifetimes: {}
+                                    parameters: {}
                                 },
                                 constraints: []
                             },
@@ -254,8 +248,7 @@ fn subgoal_cycle_uninhabited() {
                         subst: Canonical {
                             value: ConstrainedSubst {
                                 subst: Substitution {
-                                    tys: {},
-                                    lifetimes: {}
+                                    parameters: {}
                                 },
                                 constraints: []
                             },
@@ -285,10 +278,9 @@ fn subgoal_cycle_uninhabited() {
                         subst: Canonical {
                             value: ConstrainedSubst {
                                 subst: Substitution {
-                                    tys: {
+                                    parameters: {
                                         ?0: Vec<u32>
-                                    },
-                                    lifetimes: {}
+                                    }
                                 },
                                 constraints: []
                             },
@@ -310,10 +302,9 @@ fn subgoal_cycle_uninhabited() {
                         subst: Canonical {
                             value: ConstrainedSubst {
                                 subst: Substitution {
-                                    tys: {
+                                    parameters: {
                                         ?0: !1
-                                    },
-                                    lifetimes: {}
+                                    }
                                 },
                                 constraints: []
                             },
@@ -348,10 +339,9 @@ fn subgoal_cycle_inhabited() {
                         subst: Canonical {
                             value: ConstrainedSubst {
                                 subst: Substitution {
-                                    tys: {
+                                    parameters: {
                                         ?0: u32
-                                    },
-                                    lifetimes: {}
+                                    }
                                 },
                                 constraints: []
                             },
@@ -384,8 +374,7 @@ fn basic_region_constraint_from_positive_impl() {
                         subst: Canonical {
                             value: ConstrainedSubst {
                                 subst: Substitution {
-                                    tys: {},
-                                    lifetimes: {}
+                                    parameters: {}
                                 },
                                 constraints: [
                                     (Env(U3, []) |- LifetimeEq('!2, '!1))
@@ -418,8 +407,7 @@ fn basic_region_constraint_from_unification_goal() {
                         subst: Canonical {
                             value: ConstrainedSubst {
                                 subst: Substitution {
-                                    tys: {},
-                                    lifetimes: {}
+                                    parameters: {}
                                 },
                                 constraints: [
                                     (Env(U3, []) |- LifetimeEq('!2, '!1))
@@ -462,10 +450,9 @@ fn example_2_1_EWFS() {
                         subst: Canonical {
                             value: ConstrainedSubst {
                                 subst: Substitution {
-                                    tys: {
+                                    parameters: {
                                         ?0: a
-                                    },
-                                    lifetimes: {}
+                                    }
                                 },
                                 constraints: []
                             },
@@ -477,10 +464,9 @@ fn example_2_1_EWFS() {
                         subst: Canonical {
                             value: ConstrainedSubst {
                                 subst: Substitution {
-                                    tys: {
+                                    parameters: {
                                         ?0: b
-                                    },
-                                    lifetimes: {}
+                                    }
                                 },
                                 constraints: []
                             },
@@ -492,10 +478,9 @@ fn example_2_1_EWFS() {
                         subst: Canonical {
                             value: ConstrainedSubst {
                                 subst: Substitution {
-                                    tys: {
+                                    parameters: {
                                         ?0: c
-                                    },
-                                    lifetimes: {}
+                                    }
                                 },
                                 constraints: []
                             },
@@ -538,8 +523,7 @@ fn example_2_2_EWFS() {
                         subst: Canonical {
                             value: ConstrainedSubst {
                                 subst: Substitution {
-                                    tys: {},
-                                    lifetimes: {}
+                                    parameters: {}
                                 },
                                 constraints: []
                             },
@@ -582,8 +566,7 @@ fn example_2_3_EWFS() {
                         subst: Canonical {
                             value: ConstrainedSubst {
                                 subst: Substitution {
-                                    tys: {},
-                                    lifetimes: {}
+                                    parameters: {}
                                 },
                                 constraints: []
                             },
@@ -622,8 +605,7 @@ fn example_3_3_EWFS() {
                         subst: Canonical {
                             value: ConstrainedSubst {
                                 subst: Substitution {
-                                    tys: {},
-                                    lifetimes: {}
+                                    parameters: {}
                                 },
                                 constraints: []
                             },
@@ -658,8 +640,7 @@ fn contradiction() {
                         subst: Canonical {
                             value: ConstrainedSubst {
                                 subst: Substitution {
-                                    tys: {},
-                                    lifetimes: {}
+                                    parameters: {}
                                 },
                                 constraints: []
                             },
@@ -695,8 +676,7 @@ fn negative_loop() {
                         subst: Canonical {
                             value: ConstrainedSubst {
                                 subst: Substitution {
-                                    tys: {},
-                                    lifetimes: {}
+                                    parameters: {}
                                 },
                                 constraints: []
                             },
@@ -742,10 +722,9 @@ fn cached_answers_1() {
                         subst: Canonical {
                             value: ConstrainedSubst {
                                 subst: Substitution {
-                                    tys: {
+                                    parameters: {
                                         ?0: Lemon
-                                    },
-                                    lifetimes: {}
+                                    }
                                 },
                                 constraints: []
                             },
@@ -757,10 +736,9 @@ fn cached_answers_1() {
                         subst: Canonical {
                             value: ConstrainedSubst {
                                 subst: Substitution {
-                                    tys: {
+                                    parameters: {
                                         ?0: Vinegar
-                                    },
-                                    lifetimes: {}
+                                    }
                                 },
                                 constraints: []
                             },
@@ -772,10 +750,9 @@ fn cached_answers_1() {
                         subst: Canonical {
                             value: ConstrainedSubst {
                                 subst: Substitution {
-                                    tys: {
+                                    parameters: {
                                         ?0: HotSauce<?0>
-                                    },
-                                    lifetimes: {}
+                                    }
                                 },
                                 constraints: []
                             },
@@ -789,10 +766,9 @@ fn cached_answers_1() {
                         subst: Canonical {
                             value: ConstrainedSubst {
                                 subst: Substitution {
-                                    tys: {
+                                    parameters: {
                                         ?0: HotSauce<Lemon>
-                                    },
-                                    lifetimes: {}
+                                    }
                                 },
                                 constraints: []
                             },
@@ -804,10 +780,9 @@ fn cached_answers_1() {
                         subst: Canonical {
                             value: ConstrainedSubst {
                                 subst: Substitution {
-                                    tys: {
+                                    parameters: {
                                         ?0: HotSauce<Vinegar>
-                                    },
-                                    lifetimes: {}
+                                    }
                                 },
                                 constraints: []
                             },
@@ -845,10 +820,9 @@ fn cached_answers_2() {
                         subst: Canonical {
                             value: ConstrainedSubst {
                                 subst: Substitution {
-                                    tys: {
+                                    parameters: {
                                         ?0: Lemon
-                                    },
-                                    lifetimes: {}
+                                    }
                                 },
                                 constraints: []
                             },
@@ -860,10 +834,9 @@ fn cached_answers_2() {
                         subst: Canonical {
                             value: ConstrainedSubst {
                                 subst: Substitution {
-                                    tys: {
+                                    parameters: {
                                         ?0: Vinegar
-                                    },
-                                    lifetimes: {}
+                                    }
                                 },
                                 constraints: []
                             },
@@ -875,10 +848,9 @@ fn cached_answers_2() {
                         subst: Canonical {
                             value: ConstrainedSubst {
                                 subst: Substitution {
-                                    tys: {
+                                    parameters: {
                                         ?0: HotSauce<?0>
-                                    },
-                                    lifetimes: {}
+                                    }
                                 },
                                 constraints: []
                             },
@@ -892,10 +864,9 @@ fn cached_answers_2() {
                         subst: Canonical {
                             value: ConstrainedSubst {
                                 subst: Substitution {
-                                    tys: {
+                                    parameters: {
                                         ?0: HotSauce<Lemon>
-                                    },
-                                    lifetimes: {}
+                                    }
                                 },
                                 constraints: []
                             },
@@ -907,10 +878,9 @@ fn cached_answers_2() {
                         subst: Canonical {
                             value: ConstrainedSubst {
                                 subst: Substitution {
-                                    tys: {
+                                    parameters: {
                                         ?0: HotSauce<Vinegar>
-                                    },
-                                    lifetimes: {}
+                                    }
                                 },
                                 constraints: []
                             },
@@ -948,10 +918,9 @@ fn cached_answers_3() {
                         subst: Canonical {
                             value: ConstrainedSubst {
                                 subst: Substitution {
-                                    tys: {
+                                    parameters: {
                                         ?0: Lemon
-                                    },
-                                    lifetimes: {}
+                                    }
                                 },
                                 constraints: []
                             },
@@ -963,10 +932,9 @@ fn cached_answers_3() {
                         subst: Canonical {
                             value: ConstrainedSubst {
                                 subst: Substitution {
-                                    tys: {
+                                    parameters: {
                                         ?0: Vinegar
-                                    },
-                                    lifetimes: {}
+                                    }
                                 },
                                 constraints: []
                             },
@@ -978,10 +946,9 @@ fn cached_answers_3() {
                         subst: Canonical {
                             value: ConstrainedSubst {
                                 subst: Substitution {
-                                    tys: {
+                                    parameters: {
                                         ?0: HotSauce<?0>
-                                    },
-                                    lifetimes: {}
+                                    }
                                 },
                                 constraints: []
                             },
@@ -995,10 +962,9 @@ fn cached_answers_3() {
                         subst: Canonical {
                             value: ConstrainedSubst {
                                 subst: Substitution {
-                                    tys: {
+                                    parameters: {
                                         ?0: HotSauce<Lemon>
-                                    },
-                                    lifetimes: {}
+                                    }
                                 },
                                 constraints: []
                             },
@@ -1010,10 +976,9 @@ fn cached_answers_3() {
                         subst: Canonical {
                             value: ConstrainedSubst {
                                 subst: Substitution {
-                                    tys: {
+                                    parameters: {
                                         ?0: HotSauce<Vinegar>
-                                    },
-                                    lifetimes: {}
+                                    }
                                 },
                                 constraints: []
                             },

--- a/src/solve/test.rs
+++ b/src/solve/test.rs
@@ -637,7 +637,7 @@ fn region_equality() {
                 }
             }
         } yields {
-            "Unique; substitution ['?0 := '!1], lifetime constraints []"
+            "Unique; substitution [?0 := '!1], lifetime constraints []"
         }
     }
 }
@@ -1070,7 +1070,7 @@ fn unify_quantified_lifetimes() {
                 }
             }
         } yields {
-            "Unique; substitution ['?0 := '?0], lifetime constraints [
+            "Unique; substitution [?0 := '?0], lifetime constraints [
                  (Env(U1, []) |- LifetimeEq('?0, '!1))
              ]"
         }
@@ -1086,7 +1086,7 @@ fn unify_quantified_lifetimes() {
                 }
             }
         } yields {
-            "Unique; substitution ['?0 := '?0, '?1 := '!1], lifetime constraints [
+            "Unique; substitution [?0 := '?0, ?1 := '!1], lifetime constraints [
                  (Env(U1, []) |- LifetimeEq('?0, '!1))
              ]"
         }
@@ -1110,7 +1110,7 @@ fn equality_binder() {
                 }
             }
         } yields {
-            "Unique; substitution ['?0 := '?0], lifetime constraints [
+            "Unique; substitution [?0 := '?0], lifetime constraints [
                  (Env(U2, []) |- LifetimeEq('!2, '?0))
              ]"
         }
@@ -1133,7 +1133,7 @@ fn mixed_indices_unify() {
                 }
             }
         } yields {
-            "Unique; substitution [?1 := ?0, ?2 := ?0, '?0 := '?1], lifetime constraints []"
+            "Unique; substitution [?1 := ?0, ?2 := ?0, ?0 := '?1], lifetime constraints []"
         }
     }
 }
@@ -1157,7 +1157,7 @@ fn mixed_indices_match_program() {
                 }
             }
         } yields {
-            "Unique; substitution [?1 := S, ?2 := S, '?0 := '?0], lifetime constraints []"
+            "Unique; substitution [?1 := S, ?2 := S, ?0 := '?0], lifetime constraints []"
         }
     }
 }

--- a/src/solve/test.rs
+++ b/src/solve/test.rs
@@ -491,10 +491,9 @@ fn normalize_basic() {
                         subst: Canonical {
                             value: ConstrainedSubst {
                                 subst: Substitution {
-                                    tys: {
+                                    parameters: {
                                         ?0: !1
-                                    },
-                                    lifetimes: {}
+                                    }
                                 },
                                 constraints: []
                             },
@@ -506,10 +505,9 @@ fn normalize_basic() {
                         subst: Canonical {
                             value: ConstrainedSubst {
                                 subst: Substitution {
-                                    tys: {
+                                    parameters: {
                                         ?0: (Iterator::Item)<Vec<!1>>
-                                    },
-                                    lifetimes: {}
+                                    }
                                 },
                                 constraints: []
                             },
@@ -1133,7 +1131,7 @@ fn mixed_indices_unify() {
                 }
             }
         } yields {
-            "Unique; substitution [?1 := ?0, ?2 := ?0, ?0 := '?1], lifetime constraints []"
+            "Unique; substitution [?0 := '?0, ?1 := ?1, ?2 := ?1], lifetime constraints []"
         }
     }
 }
@@ -1157,7 +1155,7 @@ fn mixed_indices_match_program() {
                 }
             }
         } yields {
-            "Unique; substitution [?1 := S, ?2 := S, ?0 := '?0], lifetime constraints []"
+            "Unique; substitution [?0 := '?0, ?1 := S, ?2 := S], lifetime constraints []"
         }
     }
 }


### PR DESCRIPTION
Replace the twin vectors (types, lifetimes) in the unification table and `Substitution` and so forth into one vector.