### PR TITLE
Normalizing items when trait is unknown ("unselected" projections)

### DIFF
--- a/chalk-parse/src/ast.rs
+++ b/chalk-parse/src/ast.rs
@@ -174,6 +174,7 @@ pub enum WhereClause {
     TraitRefWellFormed { trait_ref: TraitRef },
     UnifyTys { a: Ty, b: Ty },
     UnifyLifetimes { a: Lifetime, b: Lifetime },
+    TraitInScope { trait_name: Identifier },
 }
 
 pub struct Field {

--- a/chalk-parse/src/ast.rs
+++ b/chalk-parse/src/ast.rs
@@ -123,6 +123,9 @@ pub enum Ty {
     Projection {
         proj: ProjectionTy,
     },
+    UnselectedProjection {
+        proj: UnselectedProjectionTy,
+    },
     ForAll {
         lifetime_names: Vec<Identifier>,
         ty: Box<Ty>
@@ -137,6 +140,11 @@ pub enum Lifetime {
 
 pub struct ProjectionTy {
     pub trait_ref: TraitRef,
+    pub name: Identifier,
+    pub args: Vec<Parameter>,
+}
+
+pub struct UnselectedProjectionTy {
     pub name: Identifier,
     pub args: Vec<Parameter>,
 }

--- a/chalk-parse/src/parser.lalrpop
+++ b/chalk-parse/src/parser.lalrpop
@@ -106,13 +106,19 @@ AssocTyValue: AssocTyValue = {
 };
 
 pub Ty: Ty = {
-    <n:Id> => Ty::Id { name: n},
-    <n:Id> "<" <a:Comma<Parameter>> ">" => Ty::Apply { name: n, args: a },
-    <p:ProjectionTy> => Ty::Projection { proj: p },
     "for" "<" <l:Comma<LifetimeId>> ">" <t:Ty> => Ty::ForAll {
         lifetime_names: l,
         ty: Box::new(t)
     },
+    TyWithoutFor,
+};
+
+TyWithoutFor: Ty = {
+    <n:Id> => Ty::Id { name: n},
+    <n:Id> "<" <a:Comma<Parameter>> ">" => Ty::Apply { name: n, args: a },
+    <p:ProjectionTy> => Ty::Projection { proj: p },
+    <proj:UnselectedProjectionTy> => Ty::UnselectedProjection { <> },
+    "(" <Ty> ")",
 };
 
 Lifetime: Lifetime = {
@@ -127,6 +133,17 @@ Parameter: Parameter = {
 ProjectionTy: ProjectionTy = {
     "<" <t:TraitRef<"as">> ">" "::" <n:Id> <a:Angle<Parameter>> => ProjectionTy {
         trait_ref: t, name: n, args: a
+    },
+};
+
+UnselectedProjectionTy: UnselectedProjectionTy = {
+    <ty:TyWithoutFor> "::" <name:Id> <a:Angle<Parameter>> => {
+        let mut args = vec![Parameter::Ty(ty)];
+        args.extend(a);
+        UnselectedProjectionTy {
+            name: name,
+            args: args,
+        }
     },
 };
 

--- a/chalk-parse/src/parser.lalrpop
+++ b/chalk-parse/src/parser.lalrpop
@@ -186,7 +186,9 @@ WhereClause: WhereClause = {
         let trait_ref = TraitRef { trait_name: t, args: args };
         let projection = ProjectionTy { trait_ref, name, args: a2 };
         WhereClause::ProjectionEq { projection, ty }
-    }
+    },
+
+    "InScope" "(" <t:Id> ")" => WhereClause::TraitInScope { trait_name: t },
 };
 
 TraitRef<S>: TraitRef = {

--- a/src/cast.rs
+++ b/src/cast.rs
@@ -75,6 +75,18 @@ impl Cast<LeafGoal> for Normalize {
     }
 }
 
+impl Cast<DomainGoal> for UnselectedNormalize {
+    fn cast(self) -> DomainGoal {
+        DomainGoal::UnselectedNormalize(self)
+    }
+}
+
+impl Cast<LeafGoal> for UnselectedNormalize {
+    fn cast(self) -> LeafGoal {
+        LeafGoal::DomainGoal(self.cast())
+    }
+}
+
 impl Cast<DomainGoal> for WellFormed {
     fn cast(self) -> DomainGoal {
         DomainGoal::WellFormed(self)
@@ -95,6 +107,13 @@ impl Cast<Goal> for WellFormed {
 }
 
 impl Cast<Goal> for Normalize {
+    fn cast(self) -> Goal {
+        let wcg: LeafGoal = self.cast();
+        wcg.cast()
+    }
+}
+
+impl Cast<Goal> for UnselectedNormalize {
     fn cast(self) -> Goal {
         let wcg: LeafGoal = self.cast();
         wcg.cast()

--- a/src/fold/mod.rs
+++ b/src/fold/mod.rs
@@ -268,6 +268,7 @@ pub fn super_fold_ty(folder: &mut Folder, ty: &Ty, binders: usize) -> Fallible<T
             }
         }
         Ty::Projection(ref proj) => Ok(Ty::Projection(proj.fold_with(folder, binders)?)),
+        Ty::UnselectedProjection(ref proj) => Ok(Ty::UnselectedProjection(proj.fold_with(folder, binders)?)),
         Ty::ForAll(ref quantified_ty) => Ok(Ty::ForAll(quantified_ty.fold_with(folder, binders)?)),
     }
 }
@@ -403,7 +404,7 @@ macro_rules! enum_fold {
 
 enum_fold!(PolarizedTraitRef[] { Positive(a), Negative(a) });
 enum_fold!(ParameterKind[T,L] { Ty(a), Lifetime(a) } where T: Fold, L: Fold);
-enum_fold!(DomainGoal[] { Implemented(a), Normalize(a), WellFormed(a), InScope(a) });
+enum_fold!(DomainGoal[] { Implemented(a), Normalize(a), UnselectedNormalize(a), WellFormed(a), InScope(a) });
 enum_fold!(WellFormed[] { Ty(a), TraitRef(a) });
 enum_fold!(LeafGoal[] { EqGoal(a), DomainGoal(a) });
 enum_fold!(Constraint[] { LifetimeEq(a, b) });
@@ -430,11 +431,16 @@ struct_fold!(ProjectionTy {
     associated_ty_id,
     parameters,
 });
+struct_fold!(UnselectedProjectionTy {
+    type_name,
+    parameters
+});
 struct_fold!(TraitRef {
     trait_id,
     parameters,
 });
 struct_fold!(Normalize { projection, ty });
+struct_fold!(UnselectedNormalize { projection, ty });
 struct_fold!(AssociatedTyValue {
     associated_ty_id,
     value,

--- a/src/fold/mod.rs
+++ b/src/fold/mod.rs
@@ -403,7 +403,7 @@ macro_rules! enum_fold {
 
 enum_fold!(PolarizedTraitRef[] { Positive(a), Negative(a) });
 enum_fold!(ParameterKind[T,L] { Ty(a), Lifetime(a) } where T: Fold, L: Fold);
-enum_fold!(DomainGoal[] { Implemented(a), Normalize(a), WellFormed(a) });
+enum_fold!(DomainGoal[] { Implemented(a), Normalize(a), WellFormed(a), InScope(a) });
 enum_fold!(WellFormed[] { Ty(a), TraitRef(a) });
 enum_fold!(LeafGoal[] { EqGoal(a), DomainGoal(a) });
 enum_fold!(Constraint[] { LifetimeEq(a, b) });

--- a/src/ir/debug.rs
+++ b/src/ir/debug.rs
@@ -56,6 +56,7 @@ impl Debug for Ty {
             Ty::Var(depth) => write!(fmt, "?{}", depth),
             Ty::Apply(ref apply) => write!(fmt, "{:?}", apply),
             Ty::Projection(ref proj) => write!(fmt, "{:?}", proj),
+            Ty::UnselectedProjection(ref proj) => write!(fmt, "{:?}", proj),
             Ty::ForAll(ref quantified_ty) => write!(fmt, "{:?}", quantified_ty),
         }
     }
@@ -118,6 +119,16 @@ impl Debug for ProjectionTy {
     }
 }
 
+impl Debug for UnselectedProjectionTy {
+    fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
+        write!(fmt,
+               "{:?}::{}{:?}",
+               self.parameters[0],
+               self.type_name,
+               Angle(&self.parameters[1..]))
+    }
+}
+
 pub struct Angle<'a, T: 'a>(pub &'a [T]);
 
 impl<'a, T: Debug> Debug for Angle<'a, T> {
@@ -143,10 +154,17 @@ impl Debug for Normalize {
     }
 }
 
+impl Debug for UnselectedNormalize {
+    fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
+        write!(fmt, "{:?} ==> {:?}", self.projection, self.ty)
+    }
+}
+
 impl Debug for DomainGoal {
     fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
         match *self {
             DomainGoal::Normalize(ref n) => write!(fmt, "{:?}", n),
+            DomainGoal::UnselectedNormalize(ref n) => write!(fmt, "{:?}", n),
             DomainGoal::Implemented(ref n) => {
                 write!(fmt,
                        "{:?}: {:?}{:?}",

--- a/src/ir/debug.rs
+++ b/src/ir/debug.rs
@@ -155,6 +155,7 @@ impl Debug for DomainGoal {
                        Angle(&n.parameters[1..]))
             }
             DomainGoal::WellFormed(ref n) => write!(fmt, "{:?}", n),
+            DomainGoal::InScope(ref n) => write!(fmt, "InScope({:?})", n),
         }
     }
 }

--- a/src/ir/mod.rs
+++ b/src/ir/mod.rs
@@ -458,6 +458,7 @@ pub enum DomainGoal {
     Implemented(TraitRef),
     Normalize(Normalize),
     WellFormed(WellFormed),
+    InScope(ItemId),
 }
 
 impl DomainGoal {

--- a/src/solve/slg/aggregate.rs
+++ b/src/solve/slg/aggregate.rs
@@ -160,8 +160,12 @@ impl<'infer> AntiUnifier<'infer> {
                 self.aggregate_projection_tys(apply1, apply2)
             }
 
+            (Ty::UnselectedProjection(apply1), Ty::UnselectedProjection(apply2)) => {
+                self.aggregate_unselected_projection_tys(apply1, apply2)
+            }
+
             // Mismatched base kinds.
-            (Ty::Var(_), _) | (Ty::ForAll(_), _) | (Ty::Apply(_), _) | (Ty::Projection(_), _) => {
+            (Ty::Var(_), _) | (Ty::ForAll(_), _) | (Ty::Apply(_), _) | (Ty::Projection(_), _) | (Ty::UnselectedProjection(_), _) => {
                 self.new_variable()
             }
         }
@@ -198,6 +202,26 @@ impl<'infer> AntiUnifier<'infer> {
             .map(|(&associated_ty_id, parameters)| {
                 Ty::Projection(ProjectionTy {
                     associated_ty_id,
+                    parameters,
+                })
+            })
+            .unwrap_or_else(|| self.new_variable())
+    }
+
+    fn aggregate_unselected_projection_tys(&mut self, proj1: &UnselectedProjectionTy, proj2: &UnselectedProjectionTy) -> Ty {
+        let UnselectedProjectionTy {
+            type_name: name1,
+            parameters: parameters1,
+        } = proj1;
+        let UnselectedProjectionTy {
+            type_name: name2,
+            parameters: parameters2,
+        } = proj2;
+
+        self.aggregate_name_and_substs(name1, parameters1, name2, parameters2)
+            .map(|(&type_name, parameters)| {
+                Ty::UnselectedProjection(UnselectedProjectionTy {
+                    type_name,
                     parameters,
                 })
             })

--- a/src/solve/test/mod.rs
+++ b/src/solve/test/mod.rs
@@ -1742,7 +1742,6 @@ fn mixed_semantics() {
     }
 }
 
-
 #[test]
 fn partial_overlap_1() {
     test! {
@@ -1840,6 +1839,29 @@ fn partial_overlap_3() {
             i32: Marker
         } yields {
             "Unique"
+        }
+    }
+}
+
+#[test]
+fn inscope() {
+    test! {
+        program {
+            trait Foo { }
+        }
+
+        goal {
+            InScope(Foo)
+        } yields {
+            "No possible solution: no applicable candidates"
+        }
+
+        goal {
+            if (InScope(Foo)) {
+                InScope(Foo)
+            }
+        } yields {
+            "Unique; substitution [], lifetime constraints []"
         }
     }
 }

--- a/src/solve/test/mod.rs
+++ b/src/solve/test/mod.rs
@@ -1853,7 +1853,7 @@ fn inscope() {
         goal {
             InScope(Foo)
         } yields {
-            "No possible solution: no applicable candidates"
+            "No possible solution"
         }
 
         goal {
@@ -1862,6 +1862,67 @@ fn inscope() {
             }
         } yields {
             "Unique; substitution [], lifetime constraints []"
+        }
+    }
+}
+
+#[test]
+fn unselected_projection() {
+    test! {
+        program {
+            trait Iterator {
+                type Item;
+            }
+
+            trait Iterator2 {
+                type Item;
+            }
+
+            struct Chars { }
+            struct char { }
+            struct char2 { }
+
+            impl Iterator for Chars {
+                type Item = char;
+            }
+
+            impl Iterator2 for Chars {
+                type Item = char2;
+            }
+        }
+
+        goal {
+            Chars::Item = char
+        } yields {
+            "No possible solution"
+        }
+
+        goal {
+            if (InScope(Iterator)) {
+                Chars::Item = char
+            }
+        } yields {
+            "Unique; substitution [], lifetime constraints []"
+        }
+
+        goal {
+            exists<T> {
+                if (InScope(Iterator)) {
+                    Chars::Item = T
+                }
+            }
+        } yields {
+            "Unique; substitution [?0 := char], lifetime constraints []"
+        }
+
+        goal {
+            exists<T> {
+                if (InScope(Iterator), InScope(Iterator2)) {
+                    Chars::Item = T
+                }
+            }
+        } yields {
+            "Ambiguous; no inference guidance"
         }
     }
 }

--- a/src/zip.rs
+++ b/src/zip.rs
@@ -201,7 +201,7 @@ macro_rules! enum_zip {
 /// variant, then zips each field of the variant in turn. Only works
 /// if all variants have a single parenthesized value right now.
 enum_zip!(PolarizedTraitRef { Positive, Negative });
-enum_zip!(DomainGoal { Implemented, Normalize, WellFormed });
+enum_zip!(DomainGoal { Implemented, Normalize, WellFormed, InScope });
 enum_zip!(LeafGoal { DomainGoal, EqGoal });
 enum_zip!(WellFormed { Ty, TraitRef });
 

--- a/src/zip.rs
+++ b/src/zip.rs
@@ -165,7 +165,9 @@ struct_zip!(TraitRef { trait_id, parameters });
 struct_zip!(InEnvironment[T] { environment, goal } where T: Zip);
 struct_zip!(ApplicationTy { name, parameters });
 struct_zip!(ProjectionTy { associated_ty_id, parameters });
+struct_zip!(UnselectedProjectionTy { type_name, parameters });
 struct_zip!(Normalize { projection, ty });
+struct_zip!(UnselectedNormalize { projection, ty });
 struct_zip!(EqGoal { a, b });
 
 impl Zip for Environment {
@@ -201,7 +203,7 @@ macro_rules! enum_zip {
 /// variant, then zips each field of the variant in turn. Only works
 /// if all variants have a single parenthesized value right now.
 enum_zip!(PolarizedTraitRef { Positive, Negative });
-enum_zip!(DomainGoal { Implemented, Normalize, WellFormed, InScope });
+enum_zip!(DomainGoal { Implemented, Normalize, UnselectedNormalize, WellFormed, InScope });
 enum_zip!(LeafGoal { DomainGoal, EqGoal });
 enum_zip!(WellFormed { Ty, TraitRef });
 


### PR DESCRIPTION
Added `(Trait::Item)` to the grammar (note the parentheses) instead of `Trait::Item` to prevent a left recursive grammar. (I am too lazy.)

Is it okay that the `SLG` solver returns `No possible solution: no answers`? Or does it indicate that I need to adjust that solver?

See also #58.