### PR TITLE
Fix `UnselectedProjectionTy` parameters

### DIFF
--- a/chalk-parse/src/parser.lalrpop
+++ b/chalk-parse/src/parser.lalrpop
@@ -134,8 +134,8 @@ ProjectionTy: ProjectionTy = {
 
 UnselectedProjectionTy: UnselectedProjectionTy = {
     <ty:TyWithoutFor> "::" <name:Id> <a:Angle<Parameter>> => {
-        let mut args = vec![Parameter::Ty(ty)];
-        args.extend(a);
+        let mut args = a;
+        args.push(Parameter::Ty(ty));
         UnselectedProjectionTy {
             name: name,
             args: args,

--- a/src/ir/debug.rs
+++ b/src/ir/debug.rs
@@ -121,12 +121,13 @@ impl Debug for ProjectionTy {
 
 impl Debug for UnselectedProjectionTy {
     fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
+        let len = self.parameters.len();
         write!(
             fmt,
             "{:?}::{}{:?}",
-            self.parameters[0],
+            self.parameters[len - 1],
             self.type_name,
-            Angle(&self.parameters[1..])
+            Angle(&self.parameters[0..(len - 1)])
         )
     }
 }


### PR DESCRIPTION
There were two problems with how `UnselectedProjectionTy` parameters where handled:

Firstly, they were in the wrong order with respect to those of `ProjectionTy`, i.e. the bound parameters of the associated type value should come first, *then* the `Self` type should come. For example, given:
```rust
trait Foo {
    type Item<'a>;
}

impl<T> Foo for T {
    type Item<'a> = Ref<'a, T>;
}
```
we would issue clauses like `UnselectedNormalize('a::Item<T> -> Ref<'a, T>) :- ...` instead of `UnselectedNormalize(T::Item<'a> -> Ref<'a, T>)`.

Secondly, if the trait ref had any more parameters (in addition of the `Self` parameter), we would add those extra parameters to the `UnselectedNormalize` clause in `ir::AssociatedTyValue::to_program_clauses`. For example, given:
```rust
trait Foo<U> {
    type Item;
}

impl<T, U> Foo<U> for T {
    type Item = T;
}
```
we would issue clauses like `UnselectedNormalize(T::Item<U> -> T) :- ...` instead of `UnselectedNormalize(T::Item -> T)`.

This would eventually gives `zipping things of mixed type` panics. Fixes #70.