### PR TITLE
Support "extern struct" and "extern trait" in the AST and IR

### DIFF
--- a/chalk-parse/src/ast.rs
+++ b/chalk-parse/src/ast.rs
@@ -29,6 +29,11 @@ pub struct StructDefn {
     pub parameter_kinds: Vec<ParameterKind>,
     pub where_clauses: Vec<WhereClause>,
     pub fields: Vec<Field>,
+    pub flags: StructFlags,
+}
+
+pub struct StructFlags {
+    pub external: bool,
 }
 
 pub struct TraitDefn {
@@ -42,6 +47,7 @@ pub struct TraitDefn {
 pub struct TraitFlags {
     pub auto: bool,
     pub marker: bool,
+    pub external: bool,
 }
 
 pub struct AssocTyDefn {

--- a/chalk-parse/src/parser.lalrpop
+++ b/chalk-parse/src/parser.lalrpop
@@ -35,20 +35,24 @@ Goal1: Box<Goal> = {
     "(" <Goal> ")",
 };
 
+ExternalKeyword: () = "extern";
+AutoKeyword: () = "#" "[" "auto" "]";
+MarkerKeyword: () = "#" "[" "marker" "]";
+
 StructDefn: StructDefn = {
-    "struct" <n:Id><p:Angle<ParameterKind>> <w:WhereClauses> "{" <f:Fields> "}" => StructDefn {
+    <external:ExternalKeyword?> "struct" <n:Id><p:Angle<ParameterKind>> <w:WhereClauses> "{" <f:Fields> "}" => StructDefn {
         name: n,
         parameter_kinds: p,
         where_clauses: w,
         fields: f,
+        flags: StructFlags {
+            external: external.is_some(),
+        },
     }
 };
 
-AutoKeyword: () = "#" "[" "auto" "]";
-MarkerKeyword: () = "#" "[" "marker" "]";
-
 TraitDefn: TraitDefn = {
-    <auto:AutoKeyword?> <marker:MarkerKeyword?> "trait" <n:Id><p:Angle<ParameterKind>> <w:WhereClauses> "{"
+    <external:ExternalKeyword?> <auto:AutoKeyword?> <marker:MarkerKeyword?> "trait" <n:Id><p:Angle<ParameterKind>> <w:WhereClauses> "{"
         <a:AssocTyDefn*> "}" =>
     TraitDefn {
         name: n,
@@ -58,6 +62,7 @@ TraitDefn: TraitDefn = {
         flags: TraitFlags {
             auto: auto.is_some(),
             marker: marker.is_some(),
+            external: external.is_some(),
         },
     }
 };

--- a/src/ir/mod.rs
+++ b/src/ir/mod.rs
@@ -219,6 +219,12 @@ pub struct StructDatumBound {
     crate self_ty: ApplicationTy,
     crate fields: Vec<Ty>,
     crate where_clauses: Vec<DomainGoal>,
+    crate flags: StructFlags,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct StructFlags {
+    crate external: bool,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
@@ -237,6 +243,7 @@ pub struct TraitDatumBound {
 pub struct TraitFlags {
     crate auto: bool,
     crate marker: bool,
+    crate external: bool,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]

--- a/src/lower/mod.rs
+++ b/src/lower/mod.rs
@@ -535,6 +535,9 @@ impl LowerStructDefn for StructDefn {
                 self_ty,
                 fields: fields?,
                 where_clauses,
+                flags: ir::StructFlags {
+                    external: self.flags.external,
+                },
             })
         })?;
 
@@ -881,6 +884,7 @@ impl LowerTrait for TraitDefn {
                 flags: ir::TraitFlags {
                     auto: self.flags.auto,
                     marker: self.flags.marker,
+                    external: self.flags.external,
                 },
             })
         })?;

--- a/src/lower/test.rs
+++ b/src/lower/test.rs
@@ -778,3 +778,13 @@ fn projection_type_in_header() {
         }
     }
 }
+
+#[test]
+fn external_items() {
+    lowering_success! {
+        program {
+            extern trait Send { }
+            extern struct Vec<T> { }
+        }
+    }
+}


### PR DESCRIPTION
Beginning of the "open world" work by first supporting the notion of "external" traits and types, in the AST and IR.