### PR TITLE
Implement early stop for solver when no strands can invalidate the current substitution.

### DIFF
--- a/chalk-engine/src/context/mod.rs
+++ b/chalk-engine/src/context/mod.rs
@@ -157,7 +157,7 @@ pub trait AggregateOps<C: Context> {
     fn make_solution(
         &self,
         root_goal: &C::CanonicalGoalInEnvironment,
-        simplified_answers: impl IntoIterator<Item = SimplifiedAnswer<C>>,
+        simplified_answers: impl AnswerStream<C>,
     ) -> Option<C::Solution>;
 }
 
@@ -336,4 +336,16 @@ pub trait UnificationResult<C: Context, I: InferenceContext<C>> {
     /// Add the residual subgoals as new subgoals of the ex-clause.
     /// Also add region constraints.
     fn into_ex_clause(self, ex_clause: &mut ExClause<C, I>);
+}
+
+pub trait AnswerStream<C: Context> {
+    fn peek_answer(&mut self) -> Option<SimplifiedAnswer<C>>;
+    fn next_answer(&mut self) -> Option<SimplifiedAnswer<C>>;
+
+    /// Invokes `test` with each possible future answer, returning true immediately
+    /// if we find any answer for which `test` returns true.
+    fn any_future_answer(
+        &mut self,
+        test: impl FnMut(&mut C::CanonicalExClause) -> bool,
+    ) -> bool;
 }

--- a/chalk-engine/src/context/mod.rs
+++ b/chalk-engine/src/context/mod.rs
@@ -291,7 +291,7 @@ pub trait Environment<C: Context, I: InferenceContext<C>>: Debug + Clone {
 
 pub trait CanonicalExClause<C: Context>: Debug {
     /// Extracts the inner normalized substitution.
-    fn inference_normalized_subst(&self) -> C::InferenceNormalizedSubst;
+    fn inference_normalized_subst(&self) -> &C::InferenceNormalizedSubst;
 }
 
 pub trait CanonicalConstrainedSubst<C: Context>: Clone + Debug + Eq + Hash + Ord {
@@ -299,7 +299,7 @@ pub trait CanonicalConstrainedSubst<C: Context>: Clone + Debug + Eq + Hash + Ord
     fn empty_constraints(&self) -> bool;
 
     /// Extracts the inner normalized substitution.
-    fn inference_normalized_subst(&self) -> C::InferenceNormalizedSubst;
+    fn inference_normalized_subst(&self) -> &C::InferenceNormalizedSubst;
 }
 
 pub trait DomainGoal<C: Context, I: InferenceContext<C>>: Debug {
@@ -358,6 +358,6 @@ pub trait AnswerStream<C: Context> {
     /// if we find any answer for which `test` returns true.
     fn any_future_answer(
         &mut self,
-        test: impl FnMut(&mut C::InferenceNormalizedSubst) -> bool,
+        test: impl FnMut(&C::InferenceNormalizedSubst) -> bool,
     ) -> bool;
 }

--- a/chalk-engine/src/context/prelude.rs
+++ b/chalk-engine/src/context/prelude.rs
@@ -11,6 +11,7 @@ crate use super::UnificationResult;
 crate use super::GoalInEnvironment;
 crate use super::UCanonicalGoalInEnvironment;
 crate use super::UniverseMap;
+crate use super::CanonicalExClause;
 crate use super::CanonicalConstrainedSubst;
 crate use super::Goal;
 crate use super::DomainGoal;

--- a/chalk-engine/src/forest.rs
+++ b/chalk-engine/src/forest.rs
@@ -174,8 +174,8 @@ where
 
     fn any_future_answer(
         &mut self,
-        test: impl FnMut(&mut C::CanonicalExClause) -> bool,
+        test: impl FnMut(&mut C::InferenceNormalizedSubst) -> bool,
     ) -> bool {
-        self.forest.any_future_answer(self.table, test)
+        self.forest.any_future_answer(self.table, self.answer, test)
     }
 }

--- a/chalk-engine/src/forest.rs
+++ b/chalk-engine/src/forest.rs
@@ -174,7 +174,7 @@ where
 
     fn any_future_answer(
         &mut self,
-        test: impl FnMut(&mut C::InferenceNormalizedSubst) -> bool,
+        test: impl FnMut(&C::InferenceNormalizedSubst) -> bool,
     ) -> bool {
         self.forest.any_future_answer(self.table, self.answer, test)
     }

--- a/chalk-engine/src/logic.rs
+++ b/chalk-engine/src/logic.rs
@@ -107,15 +107,15 @@ impl<C: Context> Forest<C> {
         &mut self,
         table: TableIndex,
         answer: AnswerIndex,
-        mut test: impl FnMut(&mut C::InferenceNormalizedSubst) -> bool,
+        mut test: impl FnMut(&C::InferenceNormalizedSubst) -> bool,
     ) -> bool {
         if let Some(answer) = self.tables[table].answer(answer) {
             info!("answer cached = {:?}", answer);
-            return test(&mut answer.subst.inference_normalized_subst());
+            return test(answer.subst.inference_normalized_subst());
         }
 
         self.tables[table].strands_mut().any(|strand| {
-            test(&mut strand.canonical_ex_clause.inference_normalized_subst())
+            test(strand.canonical_ex_clause.inference_normalized_subst())
         })
     }
 

--- a/chalk-engine/src/logic.rs
+++ b/chalk-engine/src/logic.rs
@@ -103,6 +103,25 @@ impl<C: Context> Forest<C> {
         }
     }
 
+    pub(super) fn any_future_answer(
+        &mut self,
+        table: TableIndex,
+        mut test: impl FnMut(&mut C::CanonicalExClause) -> bool,
+    ) -> bool {
+        let mut strands = self.tables[table].strands_mut();
+
+        // If we don't have any strands at all, then we are
+        // intentionally conservative and say it may_invalidate.
+        match strands.next() {
+            None => return true,
+            Some(strand) => if test(&mut strand.canonical_ex_clause) {
+                return true
+            },
+        }
+
+        strands.any(|strand| test(&mut strand.canonical_ex_clause))
+    }
+
     /// Ensures that answer with the given index is available from the
     /// given table. Returns `Ok` if there is an answer:
     ///

--- a/src/solve/slg/implementation/mod.rs
+++ b/src/solve/slg/implementation/mod.rs
@@ -240,7 +240,7 @@ impl context::Environment<SlgContext, SlgContext> for Arc<Environment> {
 }
 
 impl Substitution {
-    fn may_invalidate(&mut self, subst: &Canonical<Substitution>) -> bool {
+    fn may_invalidate(&self, subst: &Canonical<Substitution>) -> bool {
         self.parameters
             .iter()
             .zip(&subst.value.parameters)
@@ -413,8 +413,8 @@ impl context::DomainGoal<SlgContext, SlgContext> for DomainGoal {
 }
 
 impl context::CanonicalExClause<SlgContext> for Canonical<ExClause<SlgContext, SlgContext>> {
-    fn inference_normalized_subst(&self) -> Substitution {
-        self.value.subst.clone()
+    fn inference_normalized_subst(&self) -> &Substitution {
+        &self.value.subst
     }
 }
 
@@ -423,8 +423,8 @@ impl context::CanonicalConstrainedSubst<SlgContext> for Canonical<ConstrainedSub
         self.value.constraints.is_empty()
     }
 
-    fn inference_normalized_subst(&self) -> Substitution {
-        self.value.subst.clone()
+    fn inference_normalized_subst(&self) -> &Substitution {
+        &self.value.subst
     }
 }
 

--- a/src/solve/slg/implementation/mod.rs
+++ b/src/solve/slg/implementation/mod.rs
@@ -55,6 +55,7 @@ impl context::Context for SlgContext {
     type UCanonicalGoalInEnvironment = UCanonical<InEnvironment<Goal>>;
     type UniverseMap = UniverseMap;
     type CanonicalConstrainedSubst = Canonical<ConstrainedSubst>;
+    type InferenceNormalizedSubst = Substitution;
     type Solution = Solution;
 }
 
@@ -238,11 +239,9 @@ impl context::Environment<SlgContext, SlgContext> for Arc<Environment> {
     }
 }
 
-impl Canonical<ExClause<SlgContext, SlgContext>> {
+impl Substitution {
     fn may_invalidate(&mut self, subst: &Canonical<Substitution>) -> bool {
-        self.value
-            .subst
-            .parameters
+        self.parameters
             .iter()
             .zip(&subst.value.parameters)
             .any(|(new, current)| MayInvalidate.aggregate_parameters(new, current))
@@ -413,9 +412,19 @@ impl context::DomainGoal<SlgContext, SlgContext> for DomainGoal {
     }
 }
 
+impl context::CanonicalExClause<SlgContext> for Canonical<ExClause<SlgContext, SlgContext>> {
+    fn inference_normalized_subst(&self) -> Substitution {
+        self.value.subst.clone()
+    }
+}
+
 impl context::CanonicalConstrainedSubst<SlgContext> for Canonical<ConstrainedSubst> {
     fn empty_constraints(&self) -> bool {
         self.value.constraints.is_empty()
+    }
+
+    fn inference_normalized_subst(&self) -> Substitution {
+        self.value.subst.clone()
     }
 }
 


### PR DESCRIPTION
This should hopefully be a working implementation of #81.