### PR TITLE
support transient inference contexts in the SLG solver

### DIFF
--- a/chalk-slg/src/context/mod.rs
+++ b/chalk-slg/src/context/mod.rs
@@ -77,6 +77,10 @@ pub trait Context
     /// goal we are trying to solve to produce an ex-clause.
     type ProgramClause: ProgramClause<Self>;
 
+    /// The successful result from unification: contains new subgoals
+    /// and things that can be attached to an ex-clause.
+    type UnificationResult: UnificationResult<Self>;
+
     /// A final solution that is passed back to the user. This is
     /// completely opaque to the SLG solver; it is produced by
     /// `make_solution`.
@@ -195,8 +199,6 @@ pub trait Environment<C: Context>: Debug + Clone + Eq + Ord + Hash {
 }
 
 pub trait InferenceTable<C: Context>: Clone {
-    type UnificationResult: UnificationResult<C>;
-
     // Used by: simplify
     fn instantiate_binders_universally(&mut self, arg: &C::BindersGoal) -> C::Goal;
 
@@ -237,7 +239,7 @@ pub trait InferenceTable<C: Context>: Clone {
         environment: &C::Environment,
         a: &C::Parameter,
         b: &C::Parameter,
-    ) -> Fallible<Self::UnificationResult>;
+    ) -> Fallible<C::UnificationResult>;
 }
 
 pub trait Substitution<C: Context>: Clone + Debug {}

--- a/chalk-slg/src/context/mod.rs
+++ b/chalk-slg/src/context/mod.rs
@@ -141,14 +141,14 @@ pub trait ContextOps<C: Context> {
     fn instantiate_ucanonical_goal<R>(
         &self,
         arg: &C::UCanonicalGoalInEnvironment,
-        op: impl FnOnce(Box<dyn InferenceTable<C>>, C::Substitution, C::Environment, C::Goal) -> R,
+        op: impl FnOnce(&mut dyn InferenceTable<C>, C::Substitution, C::Environment, C::Goal) -> R,
     ) -> R;
 
     fn instantiate_ex_clause<R>(
         &self,
         num_universes: usize,
         canonical_ex_clause: &C::CanonicalExClause,
-        op: impl FnOnce(Box<dyn InferenceTable<C>>, ExClause<C>) -> R
+        op: impl FnOnce(&mut dyn InferenceTable<C>, ExClause<C>) -> R
     ) -> R;
 }
 

--- a/chalk-slg/src/context/mod.rs
+++ b/chalk-slg/src/context/mod.rs
@@ -206,10 +206,7 @@ pub trait InferenceTable<C: Context>: ResolventOps<C> + TruncateOps<C> {
     fn instantiate_binders_existentially(&mut self, arg: &C::BindersGoal) -> C::Goal;
 
     // Used by: logic (but for debugging only)
-    fn debug_ex_clause(&mut self, value: &'v ExClause<C>) -> Box<Debug + 'v>;
-
-    // Used by: logic (but for debugging only)
-    fn debug_goal(&mut self, goal: &'v C::GoalInEnvironment) -> Box<Debug + 'v>;
+    fn debug_ex_clause(&mut self, value: &'v ExClause<C>) -> Box<dyn Debug + 'v>;
 
     // Used by: logic
     fn canonicalize_goal(&mut self, value: &C::GoalInEnvironment) -> C::CanonicalGoalInEnvironment;

--- a/chalk-slg/src/context/mod.rs
+++ b/chalk-slg/src/context/mod.rs
@@ -156,6 +156,11 @@ pub trait ContextOps<C: Context> {
 }
 
 pub trait ResolventOps<C: Context> {
+    /// Combines the `goal` (instantiated within `infer`) with the
+    /// given program clause to yield the start of a new strand (a
+    /// canonical ex-clause).
+    ///
+    /// The bindings in `infer` are unaffected by this operation.
     fn resolvent_clause(
         &self,
         infer: &mut C::InferenceTable,
@@ -163,7 +168,7 @@ pub trait ResolventOps<C: Context> {
         goal: &C::DomainGoal,
         subst: &C::Substitution,
         clause: &C::ProgramClause,
-    ) -> Fallible<ExClause<C>>;
+    ) -> Fallible<C::CanonicalExClause>;
 
     fn apply_answer_subst(
         &self,
@@ -198,7 +203,7 @@ pub trait Environment<C: Context>: Debug + Clone + Eq + Ord + Hash {
     fn add_clauses(&self, clauses: impl IntoIterator<Item = C::DomainGoal>) -> Self;
 }
 
-pub trait InferenceTable<C: Context>: Clone {
+pub trait InferenceTable<C: Context> {
     // Used by: simplify
     fn instantiate_binders_universally(&mut self, arg: &C::BindersGoal) -> C::Goal;
 

--- a/chalk-slg/src/context/mod.rs
+++ b/chalk-slg/src/context/mod.rs
@@ -141,16 +141,18 @@ pub trait ContextOps<C: Context> {
     /// - the table `T`
     /// - the substitution `S`
     /// - the environment and goal found by substitution `S` into `arg`
-    fn instantiate_ucanonical_goal(
+    fn instantiate_ucanonical_goal<R>(
         &self,
         arg: &C::UCanonicalGoalInEnvironment,
-    ) -> (C::InferenceTable, C::Substitution, C::Environment, C::Goal);
+        op: impl FnOnce(C::InferenceTable, C::Substitution, C::Environment, C::Goal) -> R,
+    ) -> R;
 
-    fn instantiate_ex_clause(
+    fn instantiate_ex_clause<R>(
         &self,
         num_universes: usize,
-        strand: &C::CanonicalExClause,
-    ) -> (C::InferenceTable, ExClause<C>);
+        canonical_ex_clause: &C::CanonicalExClause,
+        op: impl FnOnce(C::InferenceTable, ExClause<C>) -> R
+    ) -> R;
 }
 
 pub trait ResolventOps<C: Context> {

--- a/chalk-slg/src/context/mod.rs
+++ b/chalk-slg/src/context/mod.rs
@@ -7,10 +7,10 @@ use std::hash::Hash;
 crate mod prelude;
 
 pub trait Context
-    : Sized + Clone + Debug + ContextOps<Self> + Aggregate<Self> + TruncateOps<Self> + ResolventOps<Self>
+    : Sized + Clone + Debug + ContextOps<Self> + Aggregate<Self>
 {
     /// Represents an inference table.
-    type InferenceTable: InferenceTable<Self>;
+    type InferenceTable: InferenceTable<Self> + TruncateOps<Self> + ResolventOps<Self>;
 
     /// Represents a set of hypotheses that are assumed to be true.
     type Environment: Environment<Self>;
@@ -103,16 +103,14 @@ pub trait TruncateOps<C: Context> {
     /// If `subgoal` is too large, return a truncated variant (else
     /// return `None`).
     fn truncate_goal(
-        &self,
-        infer: &mut C::InferenceTable,
+        &mut self,
         subgoal: &C::GoalInEnvironment,
     ) -> Option<C::GoalInEnvironment>;
 
     /// If `subst` is too large, return a truncated variant (else
     /// return `None`).
     fn truncate_answer(
-        &self,
-        infer: &mut C::InferenceTable,
+        &mut self,
         subst: &C::Substitution,
     ) -> Option<C::Substitution>;
 }
@@ -162,8 +160,7 @@ pub trait ResolventOps<C: Context> {
     ///
     /// The bindings in `infer` are unaffected by this operation.
     fn resolvent_clause(
-        &self,
-        infer: &mut C::InferenceTable,
+        &mut self,
         environment: &C::Environment,
         goal: &C::DomainGoal,
         subst: &C::Substitution,
@@ -171,8 +168,7 @@ pub trait ResolventOps<C: Context> {
     ) -> Fallible<C::CanonicalExClause>;
 
     fn apply_answer_subst(
-        &self,
-        infer: &mut C::InferenceTable,
+        &mut self,
         ex_clause: ExClause<C>,
         selected_goal: &C::GoalInEnvironment,
         answer_table_goal: &C::CanonicalGoalInEnvironment,

--- a/chalk-slg/src/context/prelude.rs
+++ b/chalk-slg/src/context/prelude.rs
@@ -8,7 +8,6 @@ crate use super::Environment;
 crate use super::InferenceTable;
 crate use super::UnificationResult;
 crate use super::GoalInEnvironment;
-crate use super::CanonicalGoalInEnvironment;
 crate use super::UCanonicalGoalInEnvironment;
 crate use super::UniverseMap;
 crate use super::Substitution;

--- a/chalk-slg/src/lib.rs
+++ b/chalk-slg/src/lib.rs
@@ -58,6 +58,7 @@
 #![feature(macro_vis_matcher)]
 #![feature(step_trait)]
 #![feature(universal_impl_trait)]
+#![feature(underscore_lifetimes)]
 
 #![allow(bare_trait_object)] // FIXME
 

--- a/chalk-slg/src/lib.rs
+++ b/chalk-slg/src/lib.rs
@@ -60,8 +60,6 @@
 #![feature(universal_impl_trait)]
 #![feature(underscore_lifetimes)]
 
-#![allow(bare_trait_object)] // FIXME
-
 #[macro_use] extern crate chalk_macros;
 extern crate stacker;
 

--- a/chalk-slg/src/lib.rs
+++ b/chalk-slg/src/lib.rs
@@ -59,6 +59,8 @@
 #![feature(step_trait)]
 #![feature(universal_impl_trait)]
 
+#![allow(bare_trait_object)] // FIXME
+
 #[macro_use] extern crate chalk_macros;
 extern crate stacker;
 

--- a/chalk-slg/src/logic.rs
+++ b/chalk-slg/src/logic.rs
@@ -674,8 +674,7 @@ impl<C: Context> Forest<C> {
                 let clauses = self.context.program_clauses(&environment, &domain_goal);
                 for clause in clauses {
                     debug!("program clause = {:#?}", clause);
-                    if let Ok(resolvent) = self.context.resolvent_clause(
-                        &mut infer,
+                    if let Ok(resolvent) = infer.resolvent_clause(
                         &environment,
                         &domain_goal,
                         &subst,
@@ -755,7 +754,7 @@ impl<C: Context> Forest<C> {
         // irrelevant answers (e.g., `Vec<Vec<u32>>: Sized`), they
         // will fail to unify with our selected goal, producing no
         // resolvent.
-        match self.context.truncate_goal(infer, subgoal) {
+        match infer.truncate_goal(subgoal) {
             None => infer.canonicalize_goal(subgoal),
             Some(truncated_subgoal) => {
                 debug!("truncated={:?}", truncated_subgoal);
@@ -866,7 +865,7 @@ impl<C: Context> Forest<C> {
         // variables that have been inverted, as discussed in the
         // prior paragraph above.) I just didn't feel like dealing
         // with it yet.
-        match self.context.truncate_goal(infer, &inverted_subgoal) {
+        match infer.truncate_goal(&inverted_subgoal) {
             Some(_) => None,
             None => Some(infer.canonicalize_goal(&inverted_subgoal)),
         }
@@ -967,8 +966,7 @@ impl<C: Context> Forest<C> {
             .map_goal_from_canonical(&self.tables[subgoal_table].table_goal.canonical());
         let answer_subst =
             &universe_map.map_subst_from_canonical(&self.answer(subgoal_table, answer_index).subst);
-        match self.context.apply_answer_subst(
-            &mut infer,
+        match infer.apply_answer_subst(
             ex_clause,
             &subgoal,
             table_goal,
@@ -1040,7 +1038,7 @@ impl<C: Context> Forest<C> {
         // aimed at giving us more times to eliminate this
         // ambiguous answer.
 
-        match self.context.truncate_answer(infer, &ex_clause.subst) {
+        match infer.truncate_answer(&ex_clause.subst) {
             // No need to truncate? Just propagate the resolvent back.
             None => ex_clause,
 

--- a/chalk-slg/src/logic.rs
+++ b/chalk-slg/src/logic.rs
@@ -674,10 +674,8 @@ impl<C: Context> Forest<C> {
                 let clauses = self.context.program_clauses(&environment, &domain_goal);
                 for clause in clauses {
                     debug!("program clause = {:#?}", clause);
-                    let mut clause_infer = infer.clone();
-
                     if let Ok(resolvent) = self.context.resolvent_clause(
-                        &mut clause_infer,
+                        &mut infer,
                         &environment,
                         &domain_goal,
                         &subst,
@@ -685,13 +683,12 @@ impl<C: Context> Forest<C> {
                     ) {
                         info!(
                             "pushing initial strand with ex-clause: {:#?}",
-                            clause_infer.debug_ex_clause(&resolvent),
+                            &resolvent,
                         );
-                        table_ref.push_strand(Self::canonicalize_strand(Strand {
-                            infer: clause_infer,
-                            ex_clause: resolvent,
+                        table_ref.push_strand(CanonicalStrand {
+                            canonical_ex_clause: resolvent,
                             selected_subgoal: None,
-                        }));
+                        });
                     }
                 }
             }

--- a/chalk-slg/src/logic.rs
+++ b/chalk-slg/src/logic.rs
@@ -607,13 +607,10 @@ impl<C: Context> Forest<C> {
     /// as possible.
     fn push_initial_strands(&mut self, table: TableIndex) {
         // Instantiate the table goal with fresh inference variables.
-        let mut infer = C::InferenceTable::new();
         let table_ref = &mut self.tables[table];
-        let subst = {
-            let table_goal = infer.instantiate_universes(&table_ref.table_goal);
-            infer.fresh_subst_for_goal(table_goal)
-        };
-        let (environment, goal) = table_ref.table_goal.canonical().substitute(&subst);
+        let (mut infer, subst, environment, goal) = self.context.instantiate_ucanonical_goal(
+            &table_ref.table_goal
+        );
 
         match goal.into_hh_goal() {
             HhGoal::DomainGoal(domain_goal) => {

--- a/chalk-slg/src/simplify.rs
+++ b/chalk-slg/src/simplify.rs
@@ -9,7 +9,7 @@ impl<C: Context> Forest<C> {
     /// and negative HH goals. This operation may fail if the HH goal
     /// includes unifications that cannot be completed.
     pub(super) fn simplify_hh_goal(
-        infer: &mut C::InferenceTable,
+        infer: &mut dyn InferenceTable<C>,
         subst: C::Substitution,
         initial_environment: &C::Environment,
         initial_hh_goal: HhGoal<C>,

--- a/chalk-slg/src/strand.rs
+++ b/chalk-slg/src/strand.rs
@@ -3,6 +3,14 @@ use crate::{ExClause, TableIndex};
 use crate::context::Context;
 use crate::table::AnswerIndex;
 
+#[derive(Debug)]
+crate struct CanonicalStrand<C: Context> {
+    pub(super) canonical_ex_clause: C::CanonicalExClause,
+
+    /// Index into `ex_clause.subgoals`.
+    crate selected_subgoal: Option<SelectedSubgoal<C>>,
+}
+
 crate struct Strand<C: Context> {
     crate infer: C::InferenceTable,
 

--- a/chalk-slg/src/strand.rs
+++ b/chalk-slg/src/strand.rs
@@ -11,8 +11,8 @@ crate struct CanonicalStrand<C: Context> {
     crate selected_subgoal: Option<SelectedSubgoal<C>>,
 }
 
-crate struct Strand<C: Context> {
-    crate infer: Box<dyn InferenceTable<C>>,
+crate struct Strand<'table, C: Context + 'table> {
+    crate infer: &'table mut dyn InferenceTable<C>,
 
     pub(super) ex_clause: ExClause<C>,
 
@@ -36,7 +36,7 @@ crate struct SelectedSubgoal<C: Context> {
     crate universe_map: C::UniverseMap,
 }
 
-impl<C: Context> Debug for Strand<C> {
+impl<'table, C: Context> Debug for Strand<'table, C> {
     fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
         fmt.debug_struct("Strand")
             .field("ex_clause", &self.ex_clause)

--- a/chalk-slg/src/strand.rs
+++ b/chalk-slg/src/strand.rs
@@ -1,6 +1,6 @@
 use std::fmt::{Debug, Error, Formatter};
 use crate::{ExClause, TableIndex};
-use crate::context::Context;
+use crate::context::{Context, InferenceTable};
 use crate::table::AnswerIndex;
 
 #[derive(Debug)]
@@ -12,7 +12,7 @@ crate struct CanonicalStrand<C: Context> {
 }
 
 crate struct Strand<C: Context> {
-    crate infer: C::InferenceTable,
+    crate infer: Box<dyn InferenceTable<C>>,
 
     pub(super) ex_clause: ExClause<C>,
 

--- a/chalk-slg/src/table.rs
+++ b/chalk-slg/src/table.rs
@@ -1,6 +1,6 @@
 use crate::{DelayedLiteralSet, DelayedLiteralSets};
 use crate::context::prelude::*;
-use crate::strand::Strand;
+use crate::strand::CanonicalStrand;
 use std::collections::{HashMap, VecDeque};
 use std::collections::hash_map::Entry;
 use std::mem;
@@ -28,7 +28,7 @@ crate struct Table<C: Context> {
 
     /// Stores the active strands that we can "pull on" to find more
     /// answers.
-    strands: VecDeque<Strand<C>>,
+    strands: VecDeque<CanonicalStrand<C>>,
 }
 
 index_struct! {
@@ -58,23 +58,23 @@ impl<C: Context> Table<C> {
         }
     }
 
-    crate fn push_strand(&mut self, strand: Strand<C>) {
+    crate fn push_strand(&mut self, strand: CanonicalStrand<C>) {
         self.strands.push_back(strand);
     }
 
-    crate fn extend_strands(&mut self, strands: impl IntoIterator<Item = Strand<C>>) {
+    crate fn extend_strands(&mut self, strands: impl IntoIterator<Item = CanonicalStrand<C>>) {
         self.strands.extend(strands);
     }
 
-    crate fn strands_mut(&mut self) -> impl Iterator<Item = &mut Strand<C>> {
+    crate fn strands_mut(&mut self) -> impl Iterator<Item = &mut CanonicalStrand<C>> {
         self.strands.iter_mut()
     }
 
-    crate fn take_strands(&mut self) -> VecDeque<Strand<C>> {
+    crate fn take_strands(&mut self) -> VecDeque<CanonicalStrand<C>> {
         mem::replace(&mut self.strands, VecDeque::new())
     }
 
-    crate fn pop_next_strand(&mut self) -> Option<Strand<C>> {
+    crate fn pop_next_strand(&mut self) -> Option<CanonicalStrand<C>> {
         self.strands.pop_front()
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,8 @@
 #![feature(underscore_lifetimes)]
 #![feature(universal_impl_trait)]
 
+#![allow(bare_trait_object)] // FIXME
+
 extern crate chalk_parse;
 #[macro_use]
 extern crate chalk_macros;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,8 +14,6 @@
 #![feature(underscore_lifetimes)]
 #![feature(universal_impl_trait)]
 
-#![allow(bare_trait_object)] // FIXME
-
 extern crate chalk_parse;
 #[macro_use]
 extern crate chalk_macros;

--- a/src/solve/infer/mod.rs
+++ b/src/solve/infer/mod.rs
@@ -1,5 +1,6 @@
 use ena::unify as ena;
 use ir::*;
+use fold::Fold;
 use fold::shift::Shift;
 
 crate mod canonicalize;
@@ -15,7 +16,8 @@ mod test;
 use self::var::*;
 
 #[derive(Clone)]
-pub struct InferenceTable { // FIXME pub b/c of trait impl for SLG
+pub struct InferenceTable {
+    // FIXME pub b/c of trait impl for SLG
     unify: ena::UnificationTable<InferenceVariable>,
     vars: Vec<InferenceVariable>,
     max_universe: UniverseIndex,
@@ -39,6 +41,33 @@ impl InferenceTable {
         }
     }
 
+    /// Creates a new inference table, pre-populated with
+    /// `num_universes` fresh universes. Instantiates the canonical
+    /// value `canonical` within those universes (which must not
+    /// reference any universe greater than `num_universes`). Returns
+    /// the substitution mapping from each canonical binder to its
+    /// corresponding existential variable, along with the
+    /// instantiated result.
+    crate fn from_canonical<T>(
+        num_universes: usize,
+        canonical: &Canonical<T>,
+    ) -> (Self, Substitution, T::Result)
+    where
+        T: Fold,
+    {
+        let mut table = InferenceTable::new();
+
+        assert!(num_universes >= 1); // always have U0
+        for _ in 1..num_universes {
+            table.new_universe();
+        }
+
+        let subst = table.fresh_subst(&canonical.binders);
+        let value = canonical.substitute(&subst);
+
+        (table, subst, value)
+    }
+
     /// Creates and returns a fresh universe that is distinct from all
     /// others created within this inference table. This universe is
     /// able to see all previously created universes (though hopefully
@@ -47,19 +76,6 @@ impl InferenceTable {
         let u = self.max_universe.next();
         self.max_universe = u;
         u
-    }
-
-    /// Creates and returns a fresh universe that is distinct from all
-    /// others created within this inference table. This universe is
-    /// able to see all previously created universes (though hopefully
-    /// it is only brought into contact with its logical *parents*).
-    crate fn instantiate_universes<'v, T>(&mut self, value: &'v UCanonical<T>) -> &'v Canonical<T> {
-        let UCanonical { universes, canonical } = value;
-        assert!(*universes >= 1); // always have U0
-        for _ in 1 .. *universes {
-            self.new_universe();
-        }
-        canonical
     }
 
     /// Current maximum universe -- one that can see all existing names.

--- a/src/solve/slg/implementation/mod.rs
+++ b/src/solve/slg/implementation/mod.rs
@@ -60,6 +60,7 @@ impl context::Context for SlgContext {
     type Parameter = Parameter;
     type ProgramClause = ProgramClause;
     type Solution = Solution;
+    type UnificationResult = UnificationResult;
 }
 
 impl context::ContextOps<SlgContext> for SlgContext {
@@ -140,8 +141,6 @@ impl context::TruncateOps<SlgContext> for SlgContext {
 }
 
 impl context::InferenceTable<SlgContext> for InferenceTable {
-    type UnificationResult = UnificationResult;
-
     fn instantiate_binders_universally(&mut self, arg: &Binders<Box<Goal>>) -> Goal {
         *self.instantiate_binders_universally(arg)
     }
@@ -198,7 +197,7 @@ impl context::InferenceTable<SlgContext> for InferenceTable {
         environment: &Arc<Environment>,
         a: &Parameter,
         b: &Parameter,
-    ) -> Fallible<Self::UnificationResult> {
+    ) -> Fallible<UnificationResult> {
         self.unify(environment, a, b)
     }
 }

--- a/src/solve/slg/implementation/mod.rs
+++ b/src/solve/slg/implementation/mod.rs
@@ -99,11 +99,11 @@ impl context::ContextOps<SlgContext> for SlgContext {
     fn instantiate_ucanonical_goal<R>(
         &self,
         arg: &UCanonical<InEnvironment<Goal>>,
-        op: impl FnOnce(Box<dyn context::InferenceTable<SlgContext>>, Substitution, Arc<Environment>, Goal) -> R
+        op: impl FnOnce(&mut dyn context::InferenceTable<SlgContext>, Substitution, Arc<Environment>, Goal) -> R
     ) -> R {
         let (infer, subst, InEnvironment { environment, goal }) =
             InferenceTable::from_canonical(arg.universes, &arg.canonical);
-        let dyn_infer = Box::new(TruncatingInferenceTable::new(self.max_size, infer));
+        let dyn_infer = &mut TruncatingInferenceTable::new(self.max_size, infer);
         op(dyn_infer, subst, environment, goal)
     }
 
@@ -111,11 +111,11 @@ impl context::ContextOps<SlgContext> for SlgContext {
         &self,
         num_universes: usize,
         canonical_ex_clause: &Canonical<ExClause<SlgContext>>,
-        op: impl FnOnce(Box<dyn context::InferenceTable<SlgContext>>, ExClause<SlgContext>) -> R
+        op: impl FnOnce(&mut dyn context::InferenceTable<SlgContext>, ExClause<SlgContext>) -> R
     ) -> R {
         let (infer, _subst, ex_cluse) =
             InferenceTable::from_canonical(num_universes, canonical_ex_clause);
-        let dyn_infer = Box::new(TruncatingInferenceTable::new(self.max_size, infer));
+        let dyn_infer = &mut TruncatingInferenceTable::new(self.max_size, infer);
         op(dyn_infer, ex_cluse)
     }
 }

--- a/src/solve/slg/implementation/mod.rs
+++ b/src/solve/slg/implementation/mod.rs
@@ -161,11 +161,7 @@ impl context::InferenceTable<SlgContext> for TruncatingInferenceTable {
         *self.infer.instantiate_binders_existentially(arg)
     }
 
-    fn debug_ex_clause(&mut self, value: &'v ExClause<SlgContext>) -> Box<Debug + 'v> {
-        Box::new(self.infer.normalize_deep(value))
-    }
-
-    fn debug_goal(&mut self, value: &'v InEnvironment<Goal>) -> Box<Debug + 'v> {
+    fn debug_ex_clause(&mut self, value: &'v ExClause<SlgContext>) -> Box<dyn Debug + 'v> {
         Box::new(self.infer.normalize_deep(value))
     }
 

--- a/src/solve/slg/implementation/mod.rs
+++ b/src/solve/slg/implementation/mod.rs
@@ -97,23 +97,25 @@ impl context::ContextOps<SlgContext> for SlgContext {
         InEnvironment::new(environment, goal)
     }
 
-    fn instantiate_ucanonical_goal(
+    fn instantiate_ucanonical_goal<R>(
         &self,
         arg: &UCanonical<InEnvironment<Goal>>,
-    ) -> (TruncatingInferenceTable, Substitution, Arc<Environment>, Goal) {
+        op: impl FnOnce(TruncatingInferenceTable, Substitution, Arc<Environment>, Goal) -> R
+    ) -> R {
         let (infer, subst, InEnvironment { environment, goal }) =
             InferenceTable::from_canonical(arg.universes, &arg.canonical);
-        (TruncatingInferenceTable::new(self.max_size, infer), subst, environment, goal)
+        op(TruncatingInferenceTable::new(self.max_size, infer), subst, environment, goal)
     }
 
-    fn instantiate_ex_clause(
+    fn instantiate_ex_clause<R>(
         &self,
         num_universes: usize,
-        arg: &Canonical<ExClause<Self>>,
-    ) -> (TruncatingInferenceTable, ExClause<Self>) {
+        canonical_ex_clause: &Canonical<ExClause<SlgContext>>,
+        op: impl FnOnce(TruncatingInferenceTable, ExClause<SlgContext>) -> R
+    ) -> R {
         let (infer, _subst, ex_cluse) =
-            InferenceTable::from_canonical(num_universes, arg);
-        (TruncatingInferenceTable::new(self.max_size, infer), ex_cluse)
+            InferenceTable::from_canonical(num_universes, canonical_ex_clause);
+        op(TruncatingInferenceTable::new(self.max_size, infer), ex_cluse)
     }
 }
 

--- a/src/solve/slg/implementation/resolvent.rs
+++ b/src/solve/slg/implementation/resolvent.rs
@@ -3,7 +3,7 @@ use crate::fold::Fold;
 use crate::fold::shift::Shift;
 use crate::ir::*;
 use crate::solve::infer::InferenceTable;
-use crate::solve::slg::implementation::SlgContext;
+use crate::solve::slg::implementation::{SlgContext, TruncatingInferenceTable};
 use crate::zip::{Zip, Zipper};
 
 use chalk_slg::{ExClause, Literal};
@@ -46,7 +46,7 @@ use std::sync::Arc;
 //
 // is the SLG resolvent of G with C.
 
-impl context::ResolventOps<SlgContext> for SlgContext {
+impl context::ResolventOps<SlgContext> for TruncatingInferenceTable {
     /// Applies the SLG resolvent algorithm to incorporate a program
     /// clause into the main X-clause, producing a new X-clause that
     /// must be solved.
@@ -56,13 +56,12 @@ impl context::ResolventOps<SlgContext> for SlgContext {
     /// - `goal` is the goal G that we are trying to solve
     /// - `clause` is the program clause that may be useful to that end
     fn resolvent_clause(
-        &self,
-        infer: &mut InferenceTable,
+        &mut self,
         environment: &Arc<Environment>,
         goal: &DomainGoal,
         subst: &Substitution,
         clause: &ProgramClause,
-    ) -> Fallible<Canonical<ExClause<Self>>> {
+    ) -> Fallible<Canonical<ExClause<SlgContext>>> {
         // Relating the above description to our situation:
         //
         // - `goal` G, except with binders for any existential variables.
@@ -77,7 +76,7 @@ impl context::ResolventOps<SlgContext> for SlgContext {
             clause,
         );
 
-        let snapshot = infer.snapshot();
+        let snapshot = self.infer.snapshot();
 
         // C' in the description above is `consequence :- conditions`.
         //
@@ -85,12 +84,12 @@ impl context::ResolventOps<SlgContext> for SlgContext {
         let ProgramClauseImplication {
             consequence,
             conditions,
-        } = infer.instantiate_binders_existentially(&clause.implication);
+        } = self.infer.instantiate_binders_existentially(&clause.implication);
         debug!("consequence = {:?}", consequence);
         debug!("conditions = {:?}", conditions);
 
         // Unify the selected literal Li with C'.
-        let unification_result = infer.unify(environment, goal, &consequence)?;
+        let unification_result = self.infer.unify(environment, goal, &consequence)?;
 
         // Final X-clause that we will return.
         let mut ex_clause = ExClause {
@@ -111,9 +110,9 @@ impl context::ResolventOps<SlgContext> for SlgContext {
                 c => Literal::Positive(InEnvironment::new(environment, c)),
             }));
 
-        let canonical_ex_clause = infer.canonicalize(&ex_clause).quantified;
+        let canonical_ex_clause = self.infer.canonicalize(&ex_clause).quantified;
 
-        infer.rollback_to(snapshot);
+        self.infer.rollback_to(snapshot);
 
         Ok(canonical_ex_clause)
     }
@@ -197,8 +196,7 @@ impl context::ResolventOps<SlgContext> for SlgContext {
     // failure will get propagated back up.
 
     fn apply_answer_subst(
-        &self,
-        infer: &mut InferenceTable,
+        &mut self,
         ex_clause: ExClause<SlgContext>,
         selected_goal: &InEnvironment<Goal>,
         answer_table_goal: &Canonical<InEnvironment<Goal>>,
@@ -206,7 +204,7 @@ impl context::ResolventOps<SlgContext> for SlgContext {
     ) -> Fallible<ExClause<SlgContext>> {
         debug_heading!("apply_answer_subst()");
         debug!("ex_clause={:?}", ex_clause);
-        debug!("selected_goal={:?}", infer.normalize_deep(selected_goal));
+        debug!("selected_goal={:?}", self.infer.normalize_deep(selected_goal));
         debug!("answer_table_goal={:?}", answer_table_goal);
         debug!("canonical_answer_subst={:?}", canonical_answer_subst);
 
@@ -220,10 +218,10 @@ impl context::ResolventOps<SlgContext> for SlgContext {
             // to be true) winds up being true, and otherwise (if the
             // answer is false or unknown) it doesn't matter.
             constraints: answer_constraints,
-        } = infer.instantiate_canonical(&canonical_answer_subst);
+        } = self.infer.instantiate_canonical(&canonical_answer_subst);
 
         let mut ex_clause = AnswerSubstitutor::substitute(
-            infer,
+            &mut self.infer,
             &selected_goal.environment,
             &answer_subst,
             ex_clause,


### PR DESCRIPTION
This PR shifts the way that the SLG trait works to support "transient" inference contexts. In the older code, each strand in the SLG solver had an associated inference context that it would carry with it. When we created new strands, we would fork this inference context (using `clone`). (My intention was to move eventually to a persistent data structure for this, although it's not obvious that this would be faster.)

However, the approach of storing an inference context per stand was pretty incompatible with how rustc's inference contexts work. They are always bound to some closure, so you can't store them in the heap, return, and then come back and use them later. The reason for this is that rustc creates an arena per inference context to store the temporary types, and then throws this arena away when you return from the closure.

Originally, I hoped to address this by changing Rust's API to use a ["Rental-like"][rental] interface. But this proved more challenging than I anticipated. I made some progress, but I kept hitting annoying edge cases in the trait system: notably, the lack of generic associated types and the shortcomings of normalization under binders. Ironically, two of the bugs I most hope to fix via this move to Chalk! It seemed to me that this route was not going anywhere.

[rental]: https://crates.io/crates/rental

So this PR takes a different tack. The SLG solver trait now never gives ownership of an inference context away; instead, it invokes a closure with a `&mut dyn InferenceTable` dyn-trait. This means that the callee can only use that inference table during the closure and cannot allow it to "escape" onto the heap (the anonymous lifetime ensures that). 

The solver in turn then distinguishes between strands that are "at rest", waiting in some table, and the current strand. A strand-at-rest is called a `CanonicalStrand`, and it is stored in canonical form. When we pick up a strand to run with it, we create a fresh inference context, instantiate its variables, and then start using it.

As implemented, this is probably fairly inefficient. We have to do a lot of substitution on a pretty regular basis. But I'm mostly interested in pushing through until we have something that *works*, then I think we can come back and revisit some of these integration questions. See for example the last commit, which suggests that it might be worthwhile to push hard on just making inference contexts potentially really light weight (and also optimizing canonicalization).