### PR TITLE
Publish and simplify bounds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,7 +77,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "chalk"
 version = "0.1.0"
 dependencies = [
- "chalk-engine 0.1.0",
+ "chalk-engine 0.2.0",
  "chalk-macros 0.1.0",
  "chalk-parse 0.1.0",
  "diff 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -95,7 +95,7 @@ dependencies = [
 
 [[package]]
 name = "chalk-engine"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "chalk-macros 0.1.0",
  "diff 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,12 @@
 [package]
-authors = ["Niko Matsakis <niko@alum.mit.edu>"]
 name = "chalk"
 version = "0.1.0"
+description = "Model of the Rust trait system"
+license = "Apache-2.0/MIT"
+authors = ["Rust Compiler Team", "Chalk developers"]
+repository = "https://github.com/rust-lang-nursery/chalk"
+readme = "README.md"
+keywords = ["compiler", "traits", "prolog"]
 
 [dependencies]
 diff = "0.1.11"
@@ -17,12 +22,15 @@ serde_derive = "1.0"
 stacker = "0.1.2"
 
 [dependencies.chalk-parse]
+version = "0.1.0"
 path = "chalk-parse"
 
 [dependencies.chalk-macros]
+version = "0.1.0"
 path = "chalk-macros"
 
 [dependencies.chalk-engine]
+version = "0.1.0"
 path = "chalk-engine"
 
 [workspace]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ version = "0.1.0"
 path = "chalk-macros"
 
 [dependencies.chalk-engine]
-version = "0.1.0"
+version = "0.2.0"
 path = "chalk-engine"
 
 [workspace]

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-[![Join the chat at https://gitter.im/chalk-rs/Lobby](https://badges.gitter.im/chalk-rs/Lobby.svg)](https://gitter.im/chalk-rs/Lobby?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
-[![Build Status](https://travis-ci.org/nikomatsakis/rayon.svg?branch=master)](https://travis-ci.org/nikomatsakis/chalk)
+[![Join the chat at https://gitter.im/chalk-rs/Lobby](https://badges.gitter.im/chalk-rs/Lobby.svg)](https://gitter.im/rust-lang/WG-traits?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![Build Status](https://travis-ci.org/rust-lang-nursery/rayon.svg?branch=master)](https://travis-ci.org/rust-lang-nursery/chalk)
 
 # chalk
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -3,6 +3,12 @@ crates.io periodically for use by the compiler. The rest of chalk is
 not yet published, though it might be nice to publish the interpreter
 at some point.
 
+# Release 0.2.0
+
+**Tag:** `chalk-engine-v0.2.0`
+
+Remove some pointless traits from Chalk engine context.
+
 # Release 0.1.0
 
 **Tag:** `chalk-engine-v0.1.0`

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,0 +1,24 @@
+The `chalk-engine` and `chalk-macros` crates are published to
+crates.io periodically for use by the compiler. The rest of chalk is
+not yet published, though it might be nice to publish the interpreter
+at some point.
+
+# Release 0.1.0
+
+**Tag:** `chalk-engine-v0.1.0`
+
+Initial release.
+
+# Procedure to cut a release
+
+Should make a script or something, but:
+
+```
+> // update version numbers
+> cd chalk-macros
+> cargo publish
+> cd ../chalk-ngine
+> cargo publish
+> git tag chalk-engine-vXXX
+```
+

--- a/chalk-engine/Cargo.toml
+++ b/chalk-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chalk-engine"
-version = "0.1.0"
+version = "0.2.0"
 description = "Core trait engine from Chalk project"
 license = "Apache-2.0/MIT"
 authors = ["Rust Compiler Team", "Chalk developers"]

--- a/chalk-engine/Cargo.toml
+++ b/chalk-engine/Cargo.toml
@@ -1,7 +1,12 @@
 [package]
-authors = ["Niko Matsakis <niko@alum.mit.edu>"]
 name = "chalk-engine"
 version = "0.1.0"
+description = "Core trait engine from Chalk project"
+license = "Apache-2.0/MIT"
+authors = ["Rust Compiler Team", "Chalk developers"]
+repository = "https://github.com/rust-lang-nursery/chalk"
+readme = "README.md"
+keywords = ["compiler", "traits", "prolog"]
 
 [dependencies]
 diff = "0.1.11"
@@ -18,4 +23,5 @@ serde_derive = "1.0"
 stacker = "0.1.2"
 
 [dependencies.chalk-macros]
+version = "0.1.0"
 path = "../chalk-macros"

--- a/chalk-engine/README.md
+++ b/chalk-engine/README.md
@@ -1,3 +1,3 @@
 The core trait solving engine used in Chalk. This engine is meant to
-be reusable across other projects, most notably the Rust compiler
-itself.
+be reused by rustc. Other projects may of course re-use it too, if you
+have a need, but don't expect much stability in the interface yet.

--- a/chalk-engine/README.md
+++ b/chalk-engine/README.md
@@ -1,0 +1,3 @@
+The core trait solving engine used in Chalk. This engine is meant to
+be reusable across other projects, most notably the Rust compiler
+itself.

--- a/chalk-engine/src/context/mod.rs
+++ b/chalk-engine/src/context/mod.rs
@@ -28,14 +28,14 @@ pub trait Context
     /// Represents a goal along with an environment.
     type GoalInEnvironment: GoalInEnvironment<Self>;
 
-    type CanonicalExClause: Debug + Clone;
+    type CanonicalExClause: Debug;
 
     /// A canonicalized `GoalInEnvironment` -- that is, one where all
     /// free inference variables have been bound into the canonical
     /// binder. See [the rustc-guide] for more information.
     ///
     /// [the rustc-guide]: https://rust-lang-nursery.github.io/rustc-guide/traits-canonicalization.html
-    type CanonicalGoalInEnvironment: Debug + Clone;
+    type CanonicalGoalInEnvironment: Debug;
 
     /// A u-canonicalized `GoalInEnvironment` -- this is one where the
     /// free universes are renumbered to consecutive integers starting
@@ -44,11 +44,11 @@ pub trait Context
 
     /// Represents a region constraint that will be propagated back
     /// (but not verified).
-    type RegionConstraint: ConstraintInEnvironment<Self>;
+    type RegionConstraint: Debug;
 
     /// Represents a substitution from the "canonical variables" found
     /// in a canonical goal to specific values.
-    type Substitution: Substitution<Self>;
+    type Substitution: Debug;
 
     /// Part of an answer: represents a canonicalized substitution,
     /// combined with region constraints. See [the rustc-guide] for more information.
@@ -62,17 +62,17 @@ pub trait Context
     ///
     /// (In Lambda Prolog, this would be a "lambda predicate", like `T
     /// \ Goal`).
-    type BindersGoal: BindersGoal<Self>;
+    type BindersGoal: Debug;
 
     /// A term that can be quantified over and unified -- in current
     /// Chalk, either a type or lifetime.
-    type Parameter: Parameter<Self>;
+    type Parameter: Debug;
 
     /// A rule like `DomainGoal :- Goal`.
     ///
     /// `resolvent_clause` combines a program-clause and a concrete
     /// goal we are trying to solve to produce an ex-clause.
-    type ProgramClause: ProgramClause<Self>;
+    type ProgramClause: Debug;
 
     /// The successful result from unification: contains new subgoals
     /// and things that can be attached to an ex-clause.
@@ -193,7 +193,7 @@ pub trait GoalInEnvironment<C: Context>: Debug + Clone + Eq + Ord + Hash {
     fn environment(&self) -> &C::Environment;
 }
 
-pub trait Environment<C: Context>: Debug + Clone + Eq + Ord + Hash {
+pub trait Environment<C: Context>: Debug + Clone {
     // Used by: simplify
     fn add_clauses(&self, clauses: impl IntoIterator<Item = C::DomainGoal>) -> Self;
 }
@@ -239,28 +239,18 @@ pub trait InferenceTable<C: Context>: ResolventOps<C> + TruncateOps<C> {
     ) -> Fallible<C::UnificationResult>;
 }
 
-pub trait Substitution<C: Context>: Clone + Debug {}
-
 pub trait CanonicalConstrainedSubst<C: Context>: Clone + Debug + Eq + Hash + Ord {
     fn empty_constraints(&self) -> bool;
 }
 
-pub trait ConstraintInEnvironment<C: Context>: Clone + Debug + Eq + Hash + Ord {}
-
-pub trait DomainGoal<C: Context>: Clone + Debug + Eq + Hash + Ord {
+pub trait DomainGoal<C: Context>: Debug {
     fn into_goal(self) -> C::Goal;
 }
 
-pub trait Goal<C: Context>: Clone + Debug + Eq + Hash + Ord {
+pub trait Goal<C: Context>: Clone + Debug + Eq {
     fn cannot_prove() -> Self;
     fn into_hh_goal(self) -> HhGoal<C>;
 }
-
-pub trait Parameter<C: Context>: Clone + Debug + Eq + Hash + Ord {}
-
-pub trait ProgramClause<C: Context>: Debug {}
-
-pub trait BindersGoal<C: Context>: Clone + Debug + Eq + Hash + Ord {}
 
 pub trait UniverseMap<C: Context>: Clone + Debug {
     fn map_goal_from_canonical(

--- a/chalk-engine/src/context/prelude.rs
+++ b/chalk-engine/src/context/prelude.rs
@@ -10,8 +10,7 @@ crate use super::UnificationResult;
 crate use super::GoalInEnvironment;
 crate use super::UCanonicalGoalInEnvironment;
 crate use super::UniverseMap;
-crate use super::Substitution;
 crate use super::CanonicalConstrainedSubst;
 crate use super::Goal;
 crate use super::DomainGoal;
-crate use super::Parameter;
+

--- a/chalk-macros/Cargo.toml
+++ b/chalk-macros/Cargo.toml
@@ -1,7 +1,12 @@
 [package]
 name = "chalk-macros"
 version = "0.1.0"
-authors = ["Niko Matsakis <niko@alum.mit.edu>"]
+description = "Macros for Chalk"
+license = "Apache-2.0/MIT"
+authors = ["Rust Compiler Team", "Chalk developers"]
+repository = "https://github.com/rust-lang-nursery/chalk"
+readme = "README.md"
+keywords = ["compiler", "traits", "prolog"]
 
 [dependencies]
 lazy_static = "0.2.2"

--- a/chalk-macros/README.md
+++ b/chalk-macros/README.md
@@ -1,0 +1,1 @@
+Various macros used within Chalk.

--- a/chalk-parse/Cargo.toml
+++ b/chalk-parse/Cargo.toml
@@ -1,7 +1,12 @@
 [package]
 name = "chalk-parse"
 version = "0.1.0"
-authors = ["Niko Matsakis <niko@alum.mit.edu>"]
+description = "Parser for the Chalk project"
+license = "Apache-2.0/MIT"
+authors = ["Rust Compiler Team", "Chalk developers"]
+repository = "https://github.com/rust-lang-nursery/chalk"
+readme = "README.md"
+keywords = ["compiler", "traits", "prolog"]
 build = "build.rs" # LALRPOP preprocessing
 
 # Add a dependency on the LALRPOP runtime library:

--- a/chalk-parse/README.md
+++ b/chalk-parse/README.md
@@ -1,0 +1,1 @@
+Parser for the Chalk standalone trait system implementation.

--- a/src/solve/slg/implementation/mod.rs
+++ b/src/solve/slg/implementation/mod.rs
@@ -231,10 +231,6 @@ impl context::Environment<SlgContext> for Arc<Environment> {
     }
 }
 
-impl context::Substitution<SlgContext> for Substitution {}
-
-impl context::Parameter<SlgContext> for Parameter {}
-
 impl context::UniverseMap<SlgContext> for ::crate::solve::infer::ucanonicalize::UniverseMap {
     fn map_goal_from_canonical(
         &self,
@@ -250,8 +246,6 @@ impl context::UniverseMap<SlgContext> for ::crate::solve::infer::ucanonicalize::
         self.map_from_canonical(value)
     }
 }
-
-impl context::ConstraintInEnvironment<SlgContext> for InEnvironment<Constraint> {}
 
 impl context::DomainGoal<SlgContext> for DomainGoal {
     fn into_goal(self) -> Goal {
@@ -278,10 +272,6 @@ impl context::UCanonicalGoalInEnvironment<SlgContext> for UCanonical<InEnvironme
         self.is_trivial_substitution(canonical_subst)
     }
 }
-
-impl context::BindersGoal<SlgContext> for Binders<Box<Goal>> {}
-
-impl context::ProgramClause<SlgContext> for ProgramClause {}
 
 impl context::Goal<SlgContext> for Goal {
     fn cannot_prove() -> Goal {


### PR DESCRIPTION
I published [`chalk-engine` v0.1.0 to `crates.io` ](https://crates.io/crates/chalk-engine). The branch adds various bits of metadata for that.

Also, because I was being sloppy with branch hygiene, I made various simplifications to the bounds in the context trait, paring down the bounds to the minimal things that it seemed like chalk-engine needs. This is to be published as v0.2.0.

Actually, I'm a bit unsure about this -- for example, a number of things are now just `Debug`, but I see no reason that they *shouldn't* be cloned or hashed, we just don't happen to have a need for it. I was debating about setting `Debug + Clone + Eq + Ord + Hash` as the default bounds everywhere, but ultimately decided against it for now. We can always add those later.