### PR TITLE
separate inference types into their own trait

### DIFF
--- a/chalk-engine/src/context/mod.rs
+++ b/chalk-engine/src/context/mod.rs
@@ -148,10 +148,16 @@ pub trait ContextOps<C: Context> {
         &self,
         num_universes: usize,
         canonical_ex_clause: &C::CanonicalExClause,
-        op: impl FnOnce(&mut dyn InferenceTable<C>, ExClause<C>) -> R
+        op: impl WithInstantiatedExClause<C, Output = R>,
     ) -> R;
 }
 
+/// Callback trait for `instantiate_ucanonical_goal`. Unlike the other
+/// traits in this file, this is not implemented by the context crate, but rather
+/// by code in this crate.
+///
+/// This basically plays the role of an `FnOnce` -- but unlike an
+/// `FnOnce`, the `with` method is generic.
 pub trait WithInstantiatedUCanonicalGoal<C: Context> {
     type Output;
 
@@ -161,6 +167,22 @@ pub trait WithInstantiatedUCanonicalGoal<C: Context> {
         subst: C::Substitution,
         environment: C::Environment,
         goal: C::Goal,
+    ) -> Self::Output;
+}
+
+/// Callback trait for `instantiate_ex_clause`. Unlike the other
+/// traits in this file, this is not implemented by the context crate,
+/// but rather by code in this crate.
+///
+/// This basically plays the role of an `FnOnce` -- but unlike an
+/// `FnOnce`, the `with` method is generic.
+pub trait WithInstantiatedExClause<C: Context> {
+    type Output;
+
+    fn with(
+        self,
+        infer: &mut dyn InferenceTable<C>,
+        ex_clause: ExClause<C>,
     ) -> Self::Output;
 }
 

--- a/chalk-engine/src/context/mod.rs
+++ b/chalk-engine/src/context/mod.rs
@@ -141,7 +141,7 @@ pub trait ContextOps<C: Context> {
     fn instantiate_ucanonical_goal<R>(
         &self,
         arg: &C::UCanonicalGoalInEnvironment,
-        op: impl FnOnce(&mut dyn InferenceTable<C>, C::Substitution, C::Environment, C::Goal) -> R,
+        op: impl WithInstantiatedUCanonicalGoal<C, Output = R>,
     ) -> R;
 
     fn instantiate_ex_clause<R>(
@@ -150,6 +150,18 @@ pub trait ContextOps<C: Context> {
         canonical_ex_clause: &C::CanonicalExClause,
         op: impl FnOnce(&mut dyn InferenceTable<C>, ExClause<C>) -> R
     ) -> R;
+}
+
+pub trait WithInstantiatedUCanonicalGoal<C: Context> {
+    type Output;
+
+    fn with(
+        self,
+        infer: &mut impl InferenceTable<C>,
+        subst: C::Substitution,
+        environment: C::Environment,
+        goal: C::Goal,
+    ) -> Self::Output;
 }
 
 pub trait ResolventOps<C: Context> {

--- a/chalk-engine/src/context/prelude.rs
+++ b/chalk-engine/src/context/prelude.rs
@@ -6,6 +6,7 @@ crate use super::ResolventOps;
 crate use super::TruncateOps;
 crate use super::Environment;
 crate use super::InferenceTable;
+crate use super::InferenceContext;
 crate use super::UnificationResult;
 crate use super::GoalInEnvironment;
 crate use super::UCanonicalGoalInEnvironment;

--- a/chalk-engine/src/derived.rs
+++ b/chalk-engine/src/derived.rs
@@ -119,8 +119,8 @@ impl<C: Context> Hash for DelayedLiteral<C> {
 
 ///////////////////////////////////////////////////////////////////////////
 
-impl<C: Context> PartialEq for Literal<C> {
-    fn eq(&self, other: &Literal<C>) -> bool {
+impl<C: Context, I: InferenceContext<C>> PartialEq for Literal<C, I> {
+    fn eq(&self, other: &Literal<C, I>) -> bool {
         match (self, other) {
             (Literal::Positive(goal1), Literal::Positive(goal2))
             | (Literal::Negative(goal1), Literal::Negative(goal2)) => goal1 == goal2,
@@ -130,10 +130,10 @@ impl<C: Context> PartialEq for Literal<C> {
     }
 }
 
-impl<C: Context> Eq for Literal<C> {
+impl<C: Context, I: InferenceContext<C>> Eq for Literal<C, I> {
 }
 
-impl<C: Context> Hash for Literal<C> {
+impl<C: Context, I: InferenceContext<C>> Hash for Literal<C, I> {
     fn hash<H: Hasher>(&self, state: &mut H) {
         mem::discriminant(self).hash(state);
         match self {

--- a/chalk-engine/src/hh.rs
+++ b/chalk-engine/src/hh.rs
@@ -1,17 +1,17 @@
-use crate::context::Context;
+use crate::context::{Context, InferenceContext};
 
 #[derive(Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 /// A general goal; this is the full range of questions you can pose to Chalk.
-pub enum HhGoal<C: Context> {
+pub enum HhGoal<C: Context, I: InferenceContext<C>> {
     /// Introduces a binding at depth 0, shifting other bindings up
     /// (deBruijn index).
-    ForAll(C::BindersGoal),
-    Exists(C::BindersGoal),
-    Implies(Vec<C::DomainGoal>, C::Goal),
-    And(C::Goal, C::Goal),
-    Not(C::Goal),
-    Unify(C::Parameter, C::Parameter),
-    DomainGoal(C::DomainGoal),
+    ForAll(I::BindersGoal),
+    Exists(I::BindersGoal),
+    Implies(Vec<I::DomainGoal>, I::Goal),
+    And(I::Goal, I::Goal),
+    Not(I::Goal),
+    Unify(I::Parameter, I::Parameter),
+    DomainGoal(I::DomainGoal),
 
     /// Indicates something that cannot be proven to be true or false
     /// definitively. This can occur with overflow but also with

--- a/chalk-engine/src/lib.rs
+++ b/chalk-engine/src/lib.rs
@@ -63,7 +63,7 @@
 #[macro_use] extern crate chalk_macros;
 extern crate stacker;
 
-use crate::context::Context;
+use crate::context::{Context, InferenceContext};
 use std::collections::HashSet;
 use std::cmp::min;
 use std::usize;
@@ -108,20 +108,20 @@ struct DepthFirstNumber {
 
 /// The paper describes these as `A :- D | G`.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
-pub struct ExClause<C: Context> {
+pub struct ExClause<C: Context, I: InferenceContext<C>> {
     /// The substitution which, applied to the goal of our table,
     /// would yield A.
-    pub subst: C::Substitution,
+    pub subst: I::Substitution,
 
     /// Delayed literals: things that we depend on negatively,
     /// but which have not yet been fully evaluated.
     pub delayed_literals: Vec<DelayedLiteral<C>>,
 
     /// Region constraints we have accumulated.
-    pub constraints: Vec<C::RegionConstraint>,
+    pub constraints: Vec<I::RegionConstraint>,
 
     /// Subgoals: literals that must be proven
-    pub subgoals: Vec<Literal<C>>,
+    pub subgoals: Vec<Literal<C, I>>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
@@ -188,9 +188,9 @@ pub enum DelayedLiteral<C: Context> {
 
 /// Either `A` or `~A`, where `A` is a `Env |- Goal`.
 #[derive(Clone, Debug)]
-pub enum Literal<C: Context> { // FIXME: pub b/c fold
-    Positive(C::GoalInEnvironment),
-    Negative(C::GoalInEnvironment),
+pub enum Literal<C: Context, I: InferenceContext<C>> { // FIXME: pub b/c fold
+    Positive(I::GoalInEnvironment),
+    Negative(I::GoalInEnvironment),
 }
 
 /// The `Minimums` structure is used to track the dependencies between

--- a/chalk-engine/src/logic.rs
+++ b/chalk-engine/src/logic.rs
@@ -189,10 +189,12 @@ impl<C: Context> Forest<C> {
         loop {
             match self.tables[table].pop_next_strand() {
                 Some(canonical_strand) => {
-                    let result = self.with_instantiated_strand_from_table(
-                        table,
+                    let num_universes = self.tables[table].table_goal.num_universes();
+                    let result = Self::with_instantiated_strand(
+                        self.context.clone(),
+                        num_universes,
                         &canonical_strand,
-                        |this, strand| this.pursue_strand(depth, strand),
+                        |strand| self.pursue_strand(depth, strand),
                     );
                     match result {
                         Ok(answer) => {
@@ -239,21 +241,6 @@ impl<C: Context> Forest<C> {
                 }
             }
         }
-    }
-
-    fn with_instantiated_strand_from_table<R>(
-        &mut self,
-        table: TableIndex,
-        canonical_strand: &CanonicalStrand<C>,
-        op: impl FnOnce(&mut Self, Strand<'_, C>) -> R,
-    ) -> R {
-        let num_universes = self.tables[table].table_goal.num_universes();
-        Self::with_instantiated_strand(
-            self.context.clone(),
-            num_universes,
-            canonical_strand,
-            |strand| op(self, strand),
-        )
     }
 
     fn with_instantiated_strand<R>(

--- a/chalk-engine/src/strand.rs
+++ b/chalk-engine/src/strand.rs
@@ -1,6 +1,6 @@
 use std::fmt::{Debug, Error, Formatter};
 use crate::{ExClause, TableIndex};
-use crate::context::{Context, InferenceTable};
+use crate::context::{Context, InferenceContext, InferenceTable};
 use crate::table::AnswerIndex;
 
 #[derive(Debug)]
@@ -11,10 +11,10 @@ crate struct CanonicalStrand<C: Context> {
     crate selected_subgoal: Option<SelectedSubgoal<C>>,
 }
 
-crate struct Strand<'table, C: Context + 'table> {
-    crate infer: &'table mut dyn InferenceTable<C>,
+crate struct Strand<'table, C: Context + 'table, I: InferenceContext<C> + 'table> {
+    crate infer: &'table mut dyn InferenceTable<C, I>,
 
-    pub(super) ex_clause: ExClause<C>,
+    pub(super) ex_clause: ExClause<C, I>,
 
     /// Index into `ex_clause.subgoals`.
     crate selected_subgoal: Option<SelectedSubgoal<C>>,
@@ -36,7 +36,7 @@ crate struct SelectedSubgoal<C: Context> {
     crate universe_map: C::UniverseMap,
 }
 
-impl<'table, C: Context> Debug for Strand<'table, C> {
+impl<'table, C: Context, I: InferenceContext<C>> Debug for Strand<'table, C, I> {
     fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
         fmt.debug_struct("Strand")
             .field("ex_clause", &self.ex_clause)

--- a/src/solve/slg/implementation/aggregate.rs
+++ b/src/solve/slg/implementation/aggregate.rs
@@ -11,7 +11,7 @@ use super::SlgContext;
 
 /// Draws as many answers as it needs from `simplified_answers` (but
 /// no more!) in order to come up with a solution.
-impl context::Aggregate<SlgContext> for SlgContext {
+impl context::AggregateOps<SlgContext> for SlgContext {
     fn make_solution(
         &self,
         root_goal: &Canonical<InEnvironment<Goal>>,

--- a/src/solve/slg/implementation/mod.rs
+++ b/src/solve/slg/implementation/mod.rs
@@ -26,6 +26,7 @@ pub struct SlgContext {
 }
 
 pub struct TruncatingInferenceTable {
+    program: Arc<ProgramEnvironment>,
     max_size: usize,
     infer: InferenceTable,
 }
@@ -49,51 +50,17 @@ impl SlgContext {
 }
 
 impl context::Context for SlgContext {
-    type Environment = Arc<Environment>;
-    type GoalInEnvironment = InEnvironment<Goal>;
     type CanonicalGoalInEnvironment = Canonical<InEnvironment<Goal>>;
-    type CanonicalExClause = Canonical<ExClause<Self>>;
+    type CanonicalExClause = Canonical<ExClause<Self, Self>>;
     type UCanonicalGoalInEnvironment = UCanonical<InEnvironment<Goal>>;
     type UniverseMap = UniverseMap;
-    type Substitution = Substitution;
     type CanonicalConstrainedSubst = Canonical<ConstrainedSubst>;
-    type RegionConstraint = InEnvironment<Constraint>;
-    type DomainGoal = DomainGoal;
-    type Goal = Goal;
-    type BindersGoal = Binders<Box<Goal>>;
-    type Parameter = Parameter;
-    type ProgramClause = ProgramClause;
     type Solution = Solution;
-    type UnificationResult = UnificationResult;
 }
 
 impl context::ContextOps<SlgContext> for SlgContext {
     fn is_coinductive(&self, goal: &UCanonical<InEnvironment<Goal>>) -> bool {
         goal.is_coinductive(&self.program)
-    }
-
-    fn program_clauses(
-        &self,
-        environment: &Arc<Environment>,
-        goal: &DomainGoal,
-    ) -> Vec<ProgramClause> {
-        let environment_clauses = environment
-            .clauses
-            .iter()
-            .filter(|&env_clause| env_clause.could_match(goal))
-            .map(|env_clause| env_clause.clone().into_program_clause());
-
-        let program_clauses = self.program
-            .program_clauses
-            .iter()
-            .filter(|clause| clause.could_match(goal))
-            .cloned();
-
-        environment_clauses.chain(program_clauses).collect()
-    }
-
-    fn goal_in_environment(environment: &Arc<Environment>, goal: Goal) -> InEnvironment<Goal> {
-        InEnvironment::new(environment, goal)
     }
 
     fn instantiate_ucanonical_goal<R>(
@@ -103,30 +70,30 @@ impl context::ContextOps<SlgContext> for SlgContext {
     ) -> R {
         let (infer, subst, InEnvironment { environment, goal }) =
             InferenceTable::from_canonical(arg.universes, &arg.canonical);
-        let dyn_infer = &mut TruncatingInferenceTable::new(self.max_size, infer);
+        let dyn_infer = &mut TruncatingInferenceTable::new(&self.program, self.max_size, infer);
         op.with(dyn_infer, subst, environment, goal)
     }
 
     fn instantiate_ex_clause<R>(
         &self,
         num_universes: usize,
-        canonical_ex_clause: &Canonical<ExClause<SlgContext>>,
+        canonical_ex_clause: &Canonical<ExClause<SlgContext, SlgContext>>,
         op: impl context::WithInstantiatedExClause<Self, Output = R>,
     ) -> R {
         let (infer, _subst, ex_cluse) =
             InferenceTable::from_canonical(num_universes, canonical_ex_clause);
-        let dyn_infer = &mut TruncatingInferenceTable::new(self.max_size, infer);
+        let dyn_infer = &mut TruncatingInferenceTable::new(&self.program, self.max_size, infer);
         op.with(dyn_infer, ex_cluse)
     }
 }
 
 impl TruncatingInferenceTable {
-    fn new(max_size: usize, infer: InferenceTable) -> Self {
-        Self { max_size, infer }
+    fn new(program: &Arc<ProgramEnvironment>, max_size: usize, infer: InferenceTable) -> Self {
+        Self { program: program.clone(), max_size, infer }
     }
 }
 
-impl context::TruncateOps<SlgContext> for TruncatingInferenceTable {
+impl context::TruncateOps<SlgContext, SlgContext> for TruncatingInferenceTable {
     fn truncate_goal(
         &mut self,
         subgoal: &InEnvironment<Goal>,
@@ -152,7 +119,43 @@ impl context::TruncateOps<SlgContext> for TruncatingInferenceTable {
     }
 }
 
-impl context::InferenceTable<SlgContext> for TruncatingInferenceTable {
+impl context::InferenceTable<SlgContext, SlgContext> for TruncatingInferenceTable {
+}
+
+impl context::InferenceContext<SlgContext> for SlgContext {
+    type Environment = Arc<Environment>;
+    type GoalInEnvironment = InEnvironment<Goal>;
+    type Substitution = Substitution;
+    type RegionConstraint = InEnvironment<Constraint>;
+    type DomainGoal = DomainGoal;
+    type Goal = Goal;
+    type BindersGoal = Binders<Box<Goal>>;
+    type Parameter = Parameter;
+    type ProgramClause = ProgramClause;
+    type UnificationResult = UnificationResult;
+}
+
+impl context::UnificationOps<SlgContext, SlgContext> for TruncatingInferenceTable {
+    fn program_clauses(
+        &self,
+        environment: &Arc<Environment>,
+        goal: &DomainGoal,
+    ) -> Vec<ProgramClause> {
+        let environment_clauses = environment
+            .clauses
+            .iter()
+            .filter(|&env_clause| env_clause.could_match(goal))
+            .map(|env_clause| env_clause.clone().into_program_clause());
+
+        let program_clauses = self.program
+            .program_clauses
+            .iter()
+            .filter(|clause| clause.could_match(goal))
+            .cloned();
+
+        environment_clauses.chain(program_clauses).collect()
+    }
+
     fn instantiate_binders_universally(&mut self, arg: &Binders<Box<Goal>>) -> Goal {
         *self.infer.instantiate_binders_universally(arg)
     }
@@ -161,7 +164,7 @@ impl context::InferenceTable<SlgContext> for TruncatingInferenceTable {
         *self.infer.instantiate_binders_existentially(arg)
     }
 
-    fn debug_ex_clause(&mut self, value: &'v ExClause<SlgContext>) -> Box<dyn Debug + 'v> {
+    fn debug_ex_clause(&mut self, value: &'v ExClause<SlgContext, SlgContext>) -> Box<dyn Debug + 'v> {
         Box::new(self.infer.normalize_deep(value))
     }
 
@@ -169,7 +172,7 @@ impl context::InferenceTable<SlgContext> for TruncatingInferenceTable {
         self.infer.canonicalize(value).quantified
     }
 
-    fn canonicalize_ex_clause(&mut self, value: &ExClause<SlgContext>) -> Canonical<ExClause<SlgContext>> {
+    fn canonicalize_ex_clause(&mut self, value: &ExClause<SlgContext, SlgContext>) -> Canonical<ExClause<SlgContext, SlgContext>> {
         self.infer.canonicalize(value).quantified
     }
 
@@ -210,8 +213,8 @@ impl context::InferenceTable<SlgContext> for TruncatingInferenceTable {
     }
 }
 
-impl context::UnificationResult<SlgContext> for ::crate::solve::infer::unify::UnificationResult {
-    fn into_ex_clause(self, ex_clause: &mut ExClause<SlgContext>) {
+impl context::UnificationResult<SlgContext, SlgContext> for ::crate::solve::infer::unify::UnificationResult {
+    fn into_ex_clause(self, ex_clause: &mut ExClause<SlgContext, SlgContext>) {
         ex_clause
             .subgoals
             .extend(self.goals.into_iter().casted().map(Literal::Positive));
@@ -219,13 +222,17 @@ impl context::UnificationResult<SlgContext> for ::crate::solve::infer::unify::Un
     }
 }
 
-impl context::GoalInEnvironment<SlgContext> for InEnvironment<Goal> {
+impl context::GoalInEnvironment<SlgContext, SlgContext> for InEnvironment<Goal> {
+    fn new(environment: &Arc<Environment>, goal: Goal) -> InEnvironment<Goal> {
+        InEnvironment::new(environment, goal)
+    }
+
     fn environment(&self) -> &Arc<Environment> {
         &self.environment
     }
 }
 
-impl context::Environment<SlgContext> for Arc<Environment> {
+impl context::Environment<SlgContext, SlgContext> for Arc<Environment> {
     fn add_clauses(&self, clauses: impl IntoIterator<Item = DomainGoal>) -> Self {
         Environment::add_clauses(self, clauses)
     }
@@ -247,7 +254,7 @@ impl context::UniverseMap<SlgContext> for ::crate::solve::infer::ucanonicalize::
     }
 }
 
-impl context::DomainGoal<SlgContext> for DomainGoal {
+impl context::DomainGoal<SlgContext, SlgContext> for DomainGoal {
     fn into_goal(self) -> Goal {
         self.cast()
     }
@@ -273,12 +280,12 @@ impl context::UCanonicalGoalInEnvironment<SlgContext> for UCanonical<InEnvironme
     }
 }
 
-impl context::Goal<SlgContext> for Goal {
+impl context::Goal<SlgContext, SlgContext> for Goal {
     fn cannot_prove() -> Goal {
         Goal::CannotProve(())
     }
 
-    fn into_hh_goal(self) -> HhGoal<SlgContext> {
+    fn into_hh_goal(self) -> HhGoal<SlgContext, SlgContext> {
         match self {
             Goal::Quantified(QuantifierKind::ForAll, binders_goal) => HhGoal::ForAll(binders_goal),
             Goal::Quantified(QuantifierKind::Exists, binders_goal) => HhGoal::Exists(binders_goal),
@@ -292,7 +299,7 @@ impl context::Goal<SlgContext> for Goal {
     }
 }
 
-type ExClauseSlgContext = ExClause<SlgContext>;
+type ExClauseSlgContext = ExClause<SlgContext, SlgContext>;
 struct_fold!(ExClauseSlgContext {
     subst,
     delayed_literals,
@@ -300,7 +307,7 @@ struct_fold!(ExClauseSlgContext {
     subgoals,
 });
 
-type LiteralSlgContext = Literal<SlgContext>;
+type LiteralSlgContext = Literal<SlgContext, SlgContext>;
 enum_fold!(LiteralSlgContext {
     Literal :: {
         Positive(a), Negative(a)

--- a/src/solve/slg/implementation/mod.rs
+++ b/src/solve/slg/implementation/mod.rs
@@ -111,12 +111,12 @@ impl context::ContextOps<SlgContext> for SlgContext {
         &self,
         num_universes: usize,
         canonical_ex_clause: &Canonical<ExClause<SlgContext>>,
-        op: impl FnOnce(&mut dyn context::InferenceTable<SlgContext>, ExClause<SlgContext>) -> R
+        op: impl context::WithInstantiatedExClause<Self, Output = R>,
     ) -> R {
         let (infer, _subst, ex_cluse) =
             InferenceTable::from_canonical(num_universes, canonical_ex_clause);
         let dyn_infer = &mut TruncatingInferenceTable::new(self.max_size, infer);
-        op(dyn_infer, ex_cluse)
+        op.with(dyn_infer, ex_cluse)
     }
 }
 

--- a/src/solve/slg/implementation/mod.rs
+++ b/src/solve/slg/implementation/mod.rs
@@ -99,12 +99,12 @@ impl context::ContextOps<SlgContext> for SlgContext {
     fn instantiate_ucanonical_goal<R>(
         &self,
         arg: &UCanonical<InEnvironment<Goal>>,
-        op: impl FnOnce(&mut dyn context::InferenceTable<SlgContext>, Substitution, Arc<Environment>, Goal) -> R
+        op: impl context::WithInstantiatedUCanonicalGoal<Self, Output = R>,
     ) -> R {
         let (infer, subst, InEnvironment { environment, goal }) =
             InferenceTable::from_canonical(arg.universes, &arg.canonical);
         let dyn_infer = &mut TruncatingInferenceTable::new(self.max_size, infer);
-        op(dyn_infer, subst, environment, goal)
+        op.with(dyn_infer, subst, environment, goal)
     }
 
     fn instantiate_ex_clause<R>(

--- a/src/solve/slg/implementation/resolvent.rs
+++ b/src/solve/slg/implementation/resolvent.rs
@@ -46,7 +46,7 @@ use std::sync::Arc;
 //
 // is the SLG resolvent of G with C.
 
-impl context::ResolventOps<SlgContext> for TruncatingInferenceTable {
+impl context::ResolventOps<SlgContext, SlgContext> for TruncatingInferenceTable {
     /// Applies the SLG resolvent algorithm to incorporate a program
     /// clause into the main X-clause, producing a new X-clause that
     /// must be solved.
@@ -61,7 +61,7 @@ impl context::ResolventOps<SlgContext> for TruncatingInferenceTable {
         goal: &DomainGoal,
         subst: &Substitution,
         clause: &ProgramClause,
-    ) -> Fallible<Canonical<ExClause<SlgContext>>> {
+    ) -> Fallible<Canonical<ExClause<SlgContext, SlgContext>>> {
         // Relating the above description to our situation:
         //
         // - `goal` G, except with binders for any existential variables.
@@ -197,11 +197,11 @@ impl context::ResolventOps<SlgContext> for TruncatingInferenceTable {
 
     fn apply_answer_subst(
         &mut self,
-        ex_clause: ExClause<SlgContext>,
+        ex_clause: ExClause<SlgContext, SlgContext>,
         selected_goal: &InEnvironment<Goal>,
         answer_table_goal: &Canonical<InEnvironment<Goal>>,
         canonical_answer_subst: &Canonical<ConstrainedSubst>,
-    ) -> Fallible<ExClause<SlgContext>> {
+    ) -> Fallible<ExClause<SlgContext, SlgContext>> {
         debug_heading!("apply_answer_subst()");
         debug!("ex_clause={:?}", ex_clause);
         debug!("selected_goal={:?}", self.infer.normalize_deep(selected_goal));
@@ -239,7 +239,7 @@ struct AnswerSubstitutor<'t> {
     answer_subst: &'t Substitution,
     answer_binders: usize,
     pending_binders: usize,
-    ex_clause: ExClause<SlgContext>,
+    ex_clause: ExClause<SlgContext, SlgContext>,
 }
 
 impl<'t> AnswerSubstitutor<'t> {
@@ -247,10 +247,10 @@ impl<'t> AnswerSubstitutor<'t> {
         table: &mut InferenceTable,
         environment: &Arc<Environment>,
         answer_subst: &Substitution,
-        ex_clause: ExClause<SlgContext>,
+        ex_clause: ExClause<SlgContext, SlgContext>,
         answer: &T,
         pending: &T,
-    ) -> Fallible<ExClause<SlgContext>> {
+    ) -> Fallible<ExClause<SlgContext, SlgContext>> {
         let mut this = AnswerSubstitutor {
             table,
             environment,


### PR DESCRIPTION
Turns out that the existing traits were not (yet) compatible with what we need from rustc. In particular, we need to distinguish those types that may contain inference byproducts from those that definitely do not. This PR splits out a new trait `InferenceContext` from `Context` which contains those types that may contain inference byproducts; the callback when you get a new inference context must then be converted from a closure into a generic trait, so that it be generic over this `InferenceContext` type, introducing some annoying boilerplate.