### PR TITLE
Parser documentation

### DIFF
--- a/chalk-parse/src/ast.rs
+++ b/chalk-parse/src/ast.rs
@@ -13,10 +13,12 @@ impl Span {
     }
 }
 
+/// The top-level container for a parsed .chalk file.
 pub struct Program {
     pub items: Vec<Item>
 }
 
+/// The `Item` enum represents a statement in a .chalk file. 
 pub enum Item {
     StructDefn(StructDefn),
     TraitDefn(TraitDefn),
@@ -24,47 +26,109 @@ pub enum Item {
     Clause(Clause),
 }
 
+/// Represents a rust struct.
 pub struct StructDefn {
+    /// The name of the structure.
     pub name: Identifier,
+
+    /// The type and lifetime parameters for this struct. They are stored in the
+    /// order they appear in the struct definition.
     pub parameter_kinds: Vec<ParameterKind>,
+
+    /// Any bounds on the type parameters are stored here.
     pub where_clauses: Vec<QuantifiedWhereClause>,
+
+    /// The field names and types for this struct.
     pub fields: Vec<Field>,
+
+    /// Any modifiers on this struct.
     pub flags: StructFlags,
 }
 
+/// This structure contains any modifiers attached to a rust struct. Currently,
+/// only the `extern` modifier is tracked.
 pub struct StructFlags {
+    /// This flag is true if the struct is `extern`.
     pub external: bool,
 }
 
+/// Represents a rust trait.
 pub struct TraitDefn {
+    /// The name of the trait.
     pub name: Identifier,
+
+    /// The type and lifetime parameters for this trait. They are stored in the
+    /// order they appear in the trait definition.
     pub parameter_kinds: Vec<ParameterKind>,
+
+    /// Any bounds on the type parameters are stored here.
     pub where_clauses: Vec<QuantifiedWhereClause>,
+
+    /// Associated types for this trait.
     pub assoc_ty_defns: Vec<AssocTyDefn>,
+
+    /// Any modifiers on this trait.
     pub flags: TraitFlags,
 }
 
+/// This structure contains any flags attached to a rust trait.
 pub struct TraitFlags {
+
+    /// This is true if the trait is `#[auto]`.
     pub auto: bool,
+
+    /// This is true if the trait is `#[marker]`.
     pub marker: bool,
+
+    /// This is true if the trait is `extern`.
     pub external: bool,
 }
 
+/// Associated types are types defined inside of traits.
+///
+/// See also `AssocTyValue`.
+// TODO: References.
 pub struct AssocTyDefn {
+
+    /// The name of the type.
     pub name: Identifier,
+
+    /// The type and lifetime parameters for this associated type.
     pub parameter_kinds: Vec<ParameterKind>,
 }
 
+/// A generic type parameter.
+/// 
+/// Not to be confused with `Parameter`, which is a concrete type parameter.
+/// For example, for the code:
+/// ```
+/// impl<T> Foo for Vec<T> {
+///     // ...
+/// }
+/// ```
+/// The `T` in `impl<T>` is a generic type parameter.
 pub enum ParameterKind {
     Ty(Identifier),
     Lifetime(Identifier),
 }
 
+/// A concrete type parameter.
+///
+/// Not to be confused with `ParameterKind`, which is a generic type parameter.
+/// For example, for the code:
+/// ```
+/// impl<T> Foo for Vec<T> {
+///     // ...
+/// }
+/// ```
+/// The `T` in `Vec<T>` is a concrete type parameter.
 pub enum Parameter {
     Ty(Ty),
     Lifetime(Lifetime),
 }
 
+/// This enum is used as the return value of the `Kinded` trait.
+// TODO: References.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum Kind {
     Ty,
@@ -82,6 +146,8 @@ impl fmt::Display for Kind {
     }
 }
 
+/// This trait is an abstraction over the two different parameter enums,
+/// `ParameterKind` and `Parameter`.
 pub trait Kinded {
     fn kind(&self) -> Kind;
 }
@@ -104,68 +170,122 @@ impl Kinded for Parameter {
     }
 }
 
+/// Represents a trait implementation for a type.
 pub struct Impl {
+    /// The type or lifetime parameters for this impl. These are used as
+    /// parameters for the struct, the trait being impled, and the associated
+    /// types.
     pub parameter_kinds: Vec<ParameterKind>,
+
+    /// The trait this impl is implementing.
     pub trait_ref: PolarizedTraitRef,
+
+    /// Any trait bounds on type parameters.
     pub where_clauses: Vec<QuantifiedWhereClause>,
+
+    /// Associated type definitions, 
     pub assoc_ty_values: Vec<AssocTyValue>,
 }
 
+/// Represents an associated type that has been given a value inside a trait
+/// impl.
 pub struct AssocTyValue {
+    /// The name of the associated type.
     pub name: Identifier,
+
+    /// Any type or lifetime parameters for the type.
     pub parameter_kinds: Vec<ParameterKind>,
+
+    /// Any bounds on the type parameters.
     pub where_clauses: Vec<WhereClause>,
+
+    /// The new type assigned to the associated one.
     pub value: Ty,
 }
 
+/// This enum represents a type. 
 pub enum Ty {
+    /// A type with just a name.
     Id {
         name: Identifier,
     },
+
+    /// A type with a name, and type or lifetime parameters.
     Apply {
         name: Identifier,
         args: Vec<Parameter>
     },
+
+    /// A projection. See `ast::ProjectionTy`.
     Projection {
         proj: ProjectionTy,
     },
+
+    /// A projection without an explicit trait name. See
+    /// `ast::UnselectedProjectionTy`.
     UnselectedProjection {
         proj: UnselectedProjectionTy,
     },
+
+    /// A type with one or more Higher-Kinded Type Bounds. Note that this variant
+    /// is recursive.
     ForAll {
         lifetime_names: Vec<Identifier>,
         ty: Box<Ty>
     }
 }
 
+/// This struct represents a lifetime. There is only one kind of lifetime;
+/// however, this enum leaves open the possibility of more kinds in the future.
 pub enum Lifetime {
     Id {
         name: Identifier,
     }
 }
 
+/// This struct encodes a projection. A projection names an associated type of
+/// another type. For example, `<Vec<T> as Foo>::Item`.
 pub struct ProjectionTy {
     pub trait_ref: TraitRef,
     pub name: Identifier,
     pub args: Vec<Parameter>,
 }
 
+/// This is the same as a projection, except without an explicit `as`. For
+/// example, `Bar::Item`.
 pub struct UnselectedProjectionTy {
     pub name: Identifier,
     pub args: Vec<Parameter>,
 }
 
+/// Represents a Trait applied to a type, separated by some string. The type that
+/// is "recieving" the trait is the first element of the args array. For example,
+/// for a trait bound (e.g. `Foo: Bar<T>`), the `TraitRef` would look like:
+/// 
+/// ```
+/// TraitRef {
+///     trait_name: "Bar",
+///     args: ["Foo", "T"]
+/// }
+/// ```
+/// (Using strings instead of actual structures for clarity.)
+///
 pub struct TraitRef {
     pub trait_name: Identifier,
     pub args: Vec<Parameter>,
 }
 
+/// This enum specifies whether a trait ref is included or excluded from a type.
+/// 
+/// For example, `Foo: Sized` is `Positive`, but `Foo: !Sized` is negative.
+/// Trait bounds are `Positive` unless `!` is prepended to their name.
 pub enum PolarizedTraitRef {
     Positive(TraitRef),
     Negative(TraitRef),
 }
 
 impl PolarizedTraitRef {
+    /// Wraps a given `TraitRef`.
     pub fn from_bool(polarity: bool, trait_ref: TraitRef) -> PolarizedTraitRef {
         if polarity {
             PolarizedTraitRef::Positive(trait_ref)
@@ -175,22 +295,47 @@ impl PolarizedTraitRef {
     }
 }
 
+/// A valid Rust identifier, along with a `Span` specifying line numbers.
 #[derive(Copy, Clone, Debug)]
 pub struct Identifier {
     pub str: InternedString,
     pub span: Span,
 }
 
+/// A where clause; either a normal Rust trait bound, or a Chalk-specific clause.
+// TODO: Add a "See" that points to a list of Chalk's where clauses, and a
+// description of each.
 pub enum WhereClause {
+    /// A normal rust Trait bound.
+    /// Example: `Foo<T>: Bar`
     Implemented { trait_ref: TraitRef },
+
+    // TODO: Renaming a projection, I think...?
     Normalize { projection: ProjectionTy, ty: Ty },
+
+    /// Assert that a projection is equal to a specific type.
+    /// Example: `<Foo<T> as Bar>::Item == T`
     ProjectionEq { projection: ProjectionTy, ty: Ty },
+
+    // TODO: What does "well formed" mean?
     TyWellFormed { ty: Ty },
+
+    // TODO: What does "well formed" mean?
     TraitRefWellFormed { trait_ref: TraitRef },
+
+    // TODO: What does "from env" mean?
     TyFromEnv { ty: Ty },
+
+    // TODO: What does "from env" mean?
     TraitRefFromEnv { trait_ref: TraitRef },
+
+    /// Constrain the two types to be equal.
     UnifyTys { a: Ty, b: Ty },
+
+    /// Constrain the two lifetimes to be equal.
     UnifyLifetimes { a: Lifetime, b: Lifetime },
+
+    /// Assert that a trait is in scope.
     TraitInScope { trait_name: Identifier },
 }
 
@@ -199,6 +344,7 @@ pub struct QuantifiedWhereClause {
     pub where_clause: WhereClause,
 }
 
+/// A field in a struct.
 pub struct Field {
     pub name: Identifier,
     pub ty: Ty,
@@ -212,6 +358,9 @@ pub struct Clause {
     pub conditions: Vec<Box<Goal>>,
 }
 
+/// A Chalk goal.
+// TODO: Add a "See" that points to a list of Chalk's where clauses, and a
+// description of each.
 pub enum Goal {
     ForAll(Vec<ParameterKind>, Box<Goal>),
     Exists(Vec<ParameterKind>, Box<Goal>),

--- a/chalk-parse/src/ast.rs
+++ b/chalk-parse/src/ast.rs
@@ -103,11 +103,13 @@ pub struct AssocTyDefn {
 ///
 /// Not to be confused with `Parameter`, which is a concrete type parameter.
 /// For example, for the code:
-/// ```
+/// 
+/// ``` ignore
 /// impl<T> Foo for Vec<T> {
 ///     // ...
 /// }
 /// ```
+/// 
 /// The `T` in `impl<T>` is a generic type parameter.
 pub enum ParameterKind {
     Ty(Identifier),
@@ -118,11 +120,13 @@ pub enum ParameterKind {
 ///
 /// Not to be confused with `ParameterKind`, which is a generic type parameter.
 /// For example, for the code:
-/// ```
+/// 
+/// ``` ignore
 /// impl<T> Foo for Vec<T> {
 ///     // ...
 /// }
 /// ```
+/// 
 /// The `T` in `Vec<T>` is a concrete type parameter.
 pub enum Parameter {
     Ty(Ty),
@@ -264,12 +268,13 @@ pub struct UnselectedProjectionTy {
 /// is "recieving" the trait is the first element of the args array. For example,
 /// for a trait bound (e.g. `Foo: Bar<T>`), the `TraitRef` would look like:
 ///
-/// ```
+/// ``` ignore
 /// TraitRef {
 ///     trait_name: "Bar",
 ///     args: ["Foo", "T"]
 /// }
 /// ```
+///
 /// (Using strings instead of actual structures for clarity.)
 ///
 pub struct TraitRef {

--- a/chalk-parse/src/ast.rs
+++ b/chalk-parse/src/ast.rs
@@ -18,7 +18,7 @@ pub struct Program {
     pub items: Vec<Item>
 }
 
-/// The `Item` enum represents a statement in a .chalk file. 
+/// The `Item` enum represents a statement in a .chalk file.
 pub enum Item {
     StructDefn(StructDefn),
     TraitDefn(TraitDefn),
@@ -98,7 +98,7 @@ pub struct AssocTyDefn {
 }
 
 /// A generic type parameter.
-/// 
+///
 /// Not to be confused with `Parameter`, which is a concrete type parameter.
 /// For example, for the code:
 /// ```
@@ -183,7 +183,7 @@ pub struct Impl {
     /// Any trait bounds on type parameters.
     pub where_clauses: Vec<QuantifiedWhereClause>,
 
-    /// Associated type definitions, 
+    /// Associated type definitions.
     pub assoc_ty_values: Vec<AssocTyValue>,
 }
 
@@ -203,7 +203,7 @@ pub struct AssocTyValue {
     pub value: Ty,
 }
 
-/// This enum represents a type. 
+/// This enum represents a type.
 pub enum Ty {
     /// A type with just a name.
     Id {
@@ -261,7 +261,7 @@ pub struct UnselectedProjectionTy {
 /// Represents a Trait applied to a type, separated by some string. The type that
 /// is "recieving" the trait is the first element of the args array. For example,
 /// for a trait bound (e.g. `Foo: Bar<T>`), the `TraitRef` would look like:
-/// 
+///
 /// ```
 /// TraitRef {
 ///     trait_name: "Bar",
@@ -276,7 +276,7 @@ pub struct TraitRef {
 }
 
 /// This enum specifies whether a trait ref is included or excluded from a type.
-/// 
+///
 /// For example, `Foo: Sized` is `Positive`, but `Foo: !Sized` is negative.
 /// Trait bounds are `Positive` unless `!` is prepended to their name.
 pub enum PolarizedTraitRef {
@@ -339,6 +339,10 @@ pub enum WhereClause {
     TraitInScope { trait_name: Identifier },
 }
 
+/// This struct represents a where clause with a "forall <...>" quantifier.
+/// If there is no quantifier, the `parameter_kinds` array is empty.
+// TODO: Add a "See" that points to an explanation of what "forall <...>" means
+// before a where clause.
 pub struct QuantifiedWhereClause {
     pub parameter_kinds: Vec<ParameterKind>,
     pub where_clause: WhereClause,

--- a/chalk-parse/src/ast.rs
+++ b/chalk-parse/src/ast.rs
@@ -1,6 +1,7 @@
 use lalrpop_intern::InternedString;
 use std::fmt;
 
+/// A span is a range of characters in a string where an error occured.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct Span {
     pub lo: usize,
@@ -8,6 +9,7 @@ pub struct Span {
 }
 
 impl Span {
+    /// Make a new span.
     pub fn new(lo: usize, hi: usize) -> Self {
         Span { lo: lo, hi: hi }
     }

--- a/chalk-parse/src/lib.rs
+++ b/chalk-parse/src/lib.rs
@@ -1,3 +1,5 @@
+
+// Up the recursion limit, because the lalrpop parser is recursive.
 #![recursion_limit = "1024"]
 
 #[macro_use]
@@ -14,6 +16,7 @@ use errors::Result;
 use lalrpop_util::ParseError;
 use std::fmt::Write;
 
+/// Parse a .chalk file with the lalrpop parser.
 pub fn parse_program(text: &str) -> Result<ast::Program> {
     match parser::parse_Program(text) {
         Ok(v) => Ok(v),
@@ -21,6 +24,7 @@ pub fn parse_program(text: &str) -> Result<ast::Program> {
     }
 }
 
+/// Parse a type entered on the command line.
 pub fn parse_ty(text: &str) -> Result<ast::Ty> {
     match parser::parse_Ty(text) {
         Ok(v) => Ok(v),
@@ -28,15 +32,19 @@ pub fn parse_ty(text: &str) -> Result<ast::Ty> {
     }
 }
 
+/// Parse a goal entered on the command line.
 pub fn parse_goal(text: &str) -> Result<Box<ast::Goal>> {
     match parser::parse_Goal(text) {
         Ok(v) => Ok(v),
+
+        // Make the error pretty.
         Err(e) => {
+            // A closure that underlines the given range with "^^^" marks.
             let position_string = |start: usize, end: usize| {
                 let mut output = String::new();
                 let text = text.replace("\n", " ").replace("\r", " ");
-                write!(output, "position: `{}`\n", text).expect("str-write cannot fail");
-                write!(output, "           ").expect("str-write cannot fail");
+                write!(output, "position: `{}`\n", text).expect("str-write cannot fail unless OOM");
+                write!(output, "           ").expect("str-write cannot fail unless OOM");
                 for _ in 0..start { output.push_str(" "); }
                 for _ in start..end { output.push_str("^"); }
                 output.push_str("\n");

--- a/chalk-parse/src/parser.lalrpop
+++ b/chalk-parse/src/parser.lalrpop
@@ -3,9 +3,6 @@ use lalrpop_intern::intern;
 
 grammar;
 
-//////////////////////////
-// Parsing a .chalk file
-
 // The Program struct is the top-level container for the parsed file.
 // See ast::Program for more info.
 pub Program: Program = {
@@ -32,11 +29,13 @@ Item: Option<Item> = {
 // TODO: Support block comments.
 Comment: () = r"//.*";
 
+// A comma separated list of 1 or more Goals.
 pub Goal: Box<Goal> = {
     Goal1,
     <g1:Goal1> "," <g2:Goal> => Box::new(Goal::And(g1, g2)),
 };
 
+// Parse a Chalk goal. See ast::Goal.
 Goal1: Box<Goal> = {
     "forall" "<" <p:Comma<ParameterKind>> ">" "{" <g:Goal> "}" => Box::new(Goal::ForAll(p, g)),
     "exists" "<" <p:Comma<ParameterKind>> ">" "{" <g:Goal> "}" => Box::new(Goal::Exists(p, g)),
@@ -143,12 +142,12 @@ AssocTyValue: AssocTyValue = {
 
 // Parse a type name, possibly with type parameters. See ast::Ty.
 pub Ty: Ty = {
-	
-	// This option parses a type that starts with "for <lifetime> ...", also
-	// known as Higher-Ranked Trait Bounds. It then recurses to parse the rest
-	// of the type.
-	//
-	// Note that the lifetime inside the for is a generic lifetime.
+
+    // This option parses a type that starts with "for <lifetime> ...", also
+    // known as Higher-Ranked Trait Bounds. It then recurses to parse the rest
+    // of the type.
+    //
+    // Note that the lifetime inside the for is a generic lifetime.
     "for" "<" <l:Comma<LifetimeId>> ">" <t:Ty> => Ty::ForAll {
         lifetime_names: l,
         ty: Box::new(t)
@@ -270,11 +269,12 @@ QuantifiedWhereClauses: Vec<QuantifiedWhereClause> = {
 //
 // TODO: Lifetime bounds are not supported yet (e.g. "`a: `b").
 WhereClause: WhereClause = {
-	// Normal rust trait bounds.
+    // Normal rust trait bounds.
     <t:TraitRef<":">> => WhereClause::Implemented { trait_ref: t },
 
-	// Chalk-specific where clauses.
-	// TODO: Add a "See" comment that points to a list of 
+    // Chalk-specific where clauses.
+    // TODO: Add a "See" comment that points to a list of chalk where clauses
+	// and their descriptions.
     "WellFormed" "(" <t:Ty> ")" => WhereClause::TyWellFormed { ty: t },
 
     "WellFormed" "(" <t:TraitRef<":">> ")" => WhereClause::TraitRefWellFormed { trait_ref: t },
@@ -304,6 +304,9 @@ WhereClause: WhereClause = {
     "InScope" "(" <t:Id> ")" => WhereClause::TraitInScope { trait_name: t },
 };
 
+// Parses a where clause, optionally with a "forall <...>" quantifier.
+//
+// See ast::QuantifiedWhereClause
 QuantifiedWhereClause: QuantifiedWhereClause = {
     <wc:WhereClause> => QuantifiedWhereClause {
         parameter_kinds: vec![],
@@ -330,10 +333,14 @@ TraitRef<S>: TraitRef = {
     },
 };
 
+// A list of 0 or more T's, separated by the string S. (For example, S="," gives
+// a comma-separated list.)
 Separator<S, T>: Vec<T> = {
     Separator1<S, T>? => <>.unwrap_or(vec![])
 };
 
+// A list of 1 or more T's, separated by the string S. (For example, S="," gives
+// a comma-separated list.)
 Separator1<S, T>: Vec<T> = {
     <t:T> => vec![t],
     <v:Separator<S, T>> S <t:T> => {
@@ -349,6 +356,7 @@ Comma<T>: Vec<T> = {
     <Separator<",", T>>
 };
 
+// A semicolon separated list of 0 or more T's.
 #[inline]
 SemiColon<T>: Vec<T> = {
     <Separator<";", T>>
@@ -375,26 +383,3 @@ LifetimeId: Identifier = {
         span: Span::new(l, r),
     }
 };
-
-/////////////////////////////
-// Parsing goal statements
-
-// A comma separated list of 1 or more Goals.
-pub Goal: Box<Goal> = {
-    Goal1,
-    <g1:Goal1> "," <g2:Goal> => Box::new(Goal::And(g1, g2)),
-};
-
-// Parse a Chalk goal. See ast::Goal. 
-Goal1: Box<Goal> = {
-    "forall" "<" <p:Comma<ParameterKind>> ">" "{" <g:Goal> "}" => Box::new(Goal::ForAll(p, g)),
-    "exists" "<" <p:Comma<ParameterKind>> ">" "{" <g:Goal> "}" => Box::new(Goal::Exists(p, g)),
-    "if" "(" <w:Comma<WhereClause>> ")" "{" <g:Goal> "}" => Box::new(Goal::Implies(w, g)),
-    "not" "{" <g:Goal> "}" => Box::new(Goal::Not(g)),
-    <w:WhereClause> => Box::new(Goal::Leaf(w)),
-    "(" <Goal> ")",
-};
-
-
-
-

--- a/chalk-parse/src/parser.lalrpop
+++ b/chalk-parse/src/parser.lalrpop
@@ -3,14 +3,23 @@ use lalrpop_intern::intern;
 
 grammar;
 
+//////////////////////////
+// Parsing a .chalk file
+
+// The Program struct is the top-level container for the parsed file.
+// See ast::Program for more info.
 pub Program: Program = {
     Items => Program { items: <> }
 };
 
+// Each item is parsed as an Option<Item>. Before storing these into the Program
+// struct, this will filter out any None entries and flatten the result.
 Items: Vec<Item> = {
     Item* => <>.into_iter().filter_map(|v| v).collect()
 };
 
+// Items are parsed as an Option to make ignoring comments easier. See ast::Item
+// for more info.
 Item: Option<Item> = {
     Comment => None,
     StructDefn => Some(Item::StructDefn(<>)),
@@ -19,6 +28,8 @@ Item: Option<Item> = {
     Clause => Some(Item::Clause(<>)),
 };
 
+// Line Comment.
+// TODO: Support block comments.
 Comment: () = r"//.*";
 
 pub Goal: Box<Goal> = {
@@ -35,10 +46,13 @@ Goal1: Box<Goal> = {
     "(" <Goal> ")",
 };
 
+// The various keywords that can be used in structs. They have no values; instead,
+// they're parsed as an Option, and then converted to a boolean via is_some.
 ExternalKeyword: () = "extern";
 AutoKeyword: () = "#" "[" "auto" "]";
 MarkerKeyword: () = "#" "[" "marker" "]";
 
+// Parse a struct. See ast::StructDefn.
 StructDefn: StructDefn = {
     <external:ExternalKeyword?> "struct" <n:Id><p:Angle<ParameterKind>>
         <w:QuantifiedWhereClauses> "{" <f:Fields> "}" => StructDefn
@@ -53,6 +67,8 @@ StructDefn: StructDefn = {
     }
 };
 
+// Parse a trait. See ast::TraitDefn.
+// TODO: Currently, traits cannot have functions; only associated types.
 TraitDefn: TraitDefn = {
     <external:ExternalKeyword?> <auto:AutoKeyword?> <marker:MarkerKeyword?> "trait" <n:Id><p:Angle<ParameterKind>>
         <w:QuantifiedWhereClauses> "{" <a:AssocTyDefn*> "}" => TraitDefn
@@ -69,6 +85,7 @@ TraitDefn: TraitDefn = {
     }
 };
 
+// Parse an associated type. See ast::AssocTyDefn and ast::TraitDefn.
 AssocTyDefn: AssocTyDefn = {
     "type" <name:Id> <p:Angle<ParameterKind>> ";" => AssocTyDefn {
         name: name,
@@ -76,6 +93,14 @@ AssocTyDefn: AssocTyDefn = {
     }
 };
 
+// Parse an impl. Impls could be for a type by themselves, or they could be a
+// trait implementation for a type. Currently, impls are assumed to be trait
+// implementations.
+//
+// Currently, impls with functions are not supported; they may only contain
+// associated types.
+//
+// See ast::Impl.
 Impl: Impl = {
     "impl" <p:Angle<ParameterKind>> <mark:"!"?> <t:Id> <a:Angle<Parameter>> "for" <s:Ty>
         <w:QuantifiedWhereClauses> "{" <assoc:AssocTyValue*> "}" =>
@@ -94,11 +119,19 @@ Impl: Impl = {
     },
 };
 
+// Parse a generic name for a type or lifetime. Not to be confused with
+// ast::Parameter, which is concrete type or lifetime.
+//
+// See ast::ParameterKind.
+//
+// Note: Inline trait bounds are not supported. All trait bounds must occur in
+// where clauses.
 ParameterKind: ParameterKind = {
     Id => ParameterKind::Ty(<>),
     LifetimeId => ParameterKind::Lifetime(<>),
 };
 
+// Parse an associated type. See ast::AssocTyValue.
 AssocTyValue: AssocTyValue = {
     "type" <n:Id> <a:Angle<ParameterKind>> <wc:WhereClauses> "=" <v:Ty> ";" => AssocTyValue {
         name: n,
@@ -108,13 +141,22 @@ AssocTyValue: AssocTyValue = {
     },
 };
 
+// Parse a type name, possibly with type parameters. See ast::Ty.
 pub Ty: Ty = {
+	
+	// This option parses a type that starts with "for <lifetime> ...", also
+	// known as Higher-Ranked Trait Bounds. It then recurses to parse the rest
+	// of the type.
+	//
+	// Note that the lifetime inside the for is a generic lifetime.
     "for" "<" <l:Comma<LifetimeId>> ">" <t:Ty> => Ty::ForAll {
         lifetime_names: l,
         ty: Box::new(t)
     },
+
     TyWithoutFor,
 };
+
 
 TyWithoutFor: Ty = {
     <n:Id> => Ty::Id { name: n},
@@ -124,21 +166,27 @@ TyWithoutFor: Ty = {
     "(" <Ty> ")",
 };
 
+// Parse a concrete lifetime name. For parsing purposes, they look identical to
+// generic lifetime names.
 Lifetime: Lifetime = {
     <n:LifetimeId> => Lifetime::Id { name: n },
 };
 
+// Parse a concrete type parameter.
 Parameter: Parameter = {
     Ty => Parameter::Ty(<>),
     Lifetime => Parameter::Lifetime(<>),
 };
 
+// Parse a reference to the associated type of a trait. See ast::ProjectionTy.
+// This version parses a fully-qualified associated type, i.e. "<Foo as Bar>::Baz"
 ProjectionTy: ProjectionTy = {
     "<" <t:TraitRef<"as">> ">" "::" <n:Id> <a:Angle<Parameter>> => ProjectionTy {
         trait_ref: t, name: n, args: a
     },
 };
 
+// Parse a reference to the associated type of a trait. See ast::ProjectionTy.
 UnselectedProjectionTy: UnselectedProjectionTy = {
     <ty:TyWithoutFor> "::" <name:Id> <a:Angle<Parameter>> => {
         let mut args = a;
@@ -150,10 +198,12 @@ UnselectedProjectionTy: UnselectedProjectionTy = {
     },
 };
 
+// Parse a comma-separated list of struct fields. See ast::StructDefn.
 Fields: Vec<Field> = {
     <Comma<Field>>,
 };
 
+// Parse a struct field. See ast::StructDefn.
 Field: Field = {
     <n:Id> ":" <t: Ty> => Field {
         name: n,
@@ -161,6 +211,7 @@ Field: Field = {
     }
 };
 
+// Parse a forall clause. This syntax is unique to Chalk queries.
 Clause: Clause = {
     "forall" <pk:Angle<ParameterKind>> "{" <wc:WhereClause> "if" <g:Comma<Goal1>> "}" => Clause {
         parameter_kinds: pk,
@@ -199,6 +250,8 @@ InlineClause: Clause = {
     }
 };
 
+// Parse a comma-separated list of where clauses. This includes any mix of normal
+// rust where-clauses and clauses used for Chalk queries.
 WhereClauses: Vec<WhereClause> = {
     "where" <Comma<WhereClause>>,
     () => vec![],
@@ -209,9 +262,19 @@ QuantifiedWhereClauses: Vec<QuantifiedWhereClause> = {
     () => vec![],
 };
 
+// Parse a where clause. This includes normal rust where-clauses and
+// chalk-specific ones.
+//
+// TODO: Clauses with multiple traits like "A: TraitB + TraitC" are not
+// supported yet.
+//
+// TODO: Lifetime bounds are not supported yet (e.g. "`a: `b").
 WhereClause: WhereClause = {
+	// Normal rust trait bounds.
     <t:TraitRef<":">> => WhereClause::Implemented { trait_ref: t },
 
+	// Chalk-specific where clauses.
+	// TODO: Add a "See" comment that points to a list of 
     "WellFormed" "(" <t:Ty> ")" => WhereClause::TyWellFormed { ty: t },
 
     "WellFormed" "(" <t:TraitRef<":">> ")" => WhereClause::TraitRefWellFormed { trait_ref: t },
@@ -253,6 +316,9 @@ QuantifiedWhereClause: QuantifiedWhereClause = {
     },
 };
 
+// Parses a Trait applied to a type, separated by S. For example, a trait bound
+// uses S=":" (e.g. `Foo: Bar<T>`), while a fully qualified reference uses S="as"
+// (e.g. `<Foo as Bar<T>>::Item`).
 TraitRef<S>: TraitRef = {
     <s:Ty> S <t:Id> <a:Angle<Parameter>> => {
         let mut args = vec![Parameter::Ty(s)];
@@ -277,6 +343,7 @@ Separator1<S, T>: Vec<T> = {
     }
 };
 
+// A comma separated list of 0 or more T's.
 #[inline]
 Comma<T>: Vec<T> = {
     <Separator<",", T>>
@@ -287,11 +354,13 @@ SemiColon<T>: Vec<T> = {
     <Separator<";", T>>
 };
 
+// A T inside of angle brackets.
 Angle<T>: Vec<T> = {
     "<" <Comma<T>> ">",
     () => vec![],
 };
 
+// A valid name in Rust.
 Id: Identifier = {
     <l:@L> <s:r"([A-Za-z]|_)([A-Za-z0-9]|_)*"> <r:@R> => Identifier {
         str: intern(s),
@@ -299,9 +368,33 @@ Id: Identifier = {
     }
 };
 
+// A valid lifetime name in Rust.
 LifetimeId: Identifier = {
     <l:@L> <s:r"'([A-Za-z]|_)([A-Za-z0-9]|_)*"> <r:@R> => Identifier {
         str: intern(s),
         span: Span::new(l, r),
     }
 };
+
+/////////////////////////////
+// Parsing goal statements
+
+// A comma separated list of 1 or more Goals.
+pub Goal: Box<Goal> = {
+    Goal1,
+    <g1:Goal1> "," <g2:Goal> => Box::new(Goal::And(g1, g2)),
+};
+
+// Parse a Chalk goal. See ast::Goal. 
+Goal1: Box<Goal> = {
+    "forall" "<" <p:Comma<ParameterKind>> ">" "{" <g:Goal> "}" => Box::new(Goal::ForAll(p, g)),
+    "exists" "<" <p:Comma<ParameterKind>> ">" "{" <g:Goal> "}" => Box::new(Goal::Exists(p, g)),
+    "if" "(" <w:Comma<WhereClause>> ")" "{" <g:Goal> "}" => Box::new(Goal::Implies(w, g)),
+    "not" "{" <g:Goal> "}" => Box::new(Goal::Not(g)),
+    <w:WhereClause> => Box::new(Goal::Leaf(w)),
+    "(" <Goal> ")",
+};
+
+
+
+


### PR DESCRIPTION
Added lots of documentation to the parser-generator code and the ast structures.

Continuation of #89 

As before, I left some TODO's for parts that I was unsure about, or where I need to reference documentation that hasn't been written yet.