### PR TITLE
Deref domain goal

### DIFF
--- a/chalk-parse/src/ast.rs
+++ b/chalk-parse/src/ast.rs
@@ -193,6 +193,7 @@ pub enum WhereClause {
     UnifyTys { a: Ty, b: Ty },
     UnifyLifetimes { a: Lifetime, b: Lifetime },
     TraitInScope { trait_name: Identifier },
+    Derefs { source: Ty, target: Ty },
 }
 
 pub struct QuantifiedWhereClause {

--- a/chalk-parse/src/ast.rs
+++ b/chalk-parse/src/ast.rs
@@ -48,6 +48,7 @@ pub struct TraitFlags {
     pub auto: bool,
     pub marker: bool,
     pub external: bool,
+    pub deref: bool,
 }
 
 pub struct AssocTyDefn {

--- a/chalk-parse/src/parser.lalrpop
+++ b/chalk-parse/src/parser.lalrpop
@@ -38,6 +38,7 @@ Goal1: Box<Goal> = {
 ExternalKeyword: () = "extern";
 AutoKeyword: () = "#" "[" "auto" "]";
 MarkerKeyword: () = "#" "[" "marker" "]";
+DerefKeyword: () = "#" "[" "deref" "]";
 
 StructDefn: StructDefn = {
     <external:ExternalKeyword?> "struct" <n:Id><p:Angle<ParameterKind>>
@@ -54,7 +55,7 @@ StructDefn: StructDefn = {
 };
 
 TraitDefn: TraitDefn = {
-    <external:ExternalKeyword?> <auto:AutoKeyword?> <marker:MarkerKeyword?> "trait" <n:Id><p:Angle<ParameterKind>>
+    <external:ExternalKeyword?> <auto:AutoKeyword?> <marker:MarkerKeyword?> <deref:DerefKeyword?> "trait" <n:Id><p:Angle<ParameterKind>>
         <w:QuantifiedWhereClauses> "{" <a:AssocTyDefn*> "}" => TraitDefn
     {
         name: n,
@@ -65,6 +66,7 @@ TraitDefn: TraitDefn = {
             auto: auto.is_some(),
             marker: marker.is_some(),
             external: external.is_some(),
+            deref: deref.is_some(),
         },
     }
 };

--- a/chalk-parse/src/parser.lalrpop
+++ b/chalk-parse/src/parser.lalrpop
@@ -38,7 +38,7 @@ Goal1: Box<Goal> = {
 ExternalKeyword: () = "extern";
 AutoKeyword: () = "#" "[" "auto" "]";
 MarkerKeyword: () = "#" "[" "marker" "]";
-DerefKeyword: () = "#" "[" "deref" "]";
+DerefLangItem: () = "#" "[" "lang_deref" "]";
 
 StructDefn: StructDefn = {
     <external:ExternalKeyword?> "struct" <n:Id><p:Angle<ParameterKind>>
@@ -55,7 +55,7 @@ StructDefn: StructDefn = {
 };
 
 TraitDefn: TraitDefn = {
-    <external:ExternalKeyword?> <auto:AutoKeyword?> <marker:MarkerKeyword?> <deref:DerefKeyword?> "trait" <n:Id><p:Angle<ParameterKind>>
+    <external:ExternalKeyword?> <auto:AutoKeyword?> <marker:MarkerKeyword?> <deref:DerefLangItem?> "trait" <n:Id><p:Angle<ParameterKind>>
         <w:QuantifiedWhereClauses> "{" <a:AssocTyDefn*> "}" => TraitDefn
     {
         name: n,
@@ -241,6 +241,7 @@ WhereClause: WhereClause = {
     },
 
     "InScope" "(" <t:Id> ")" => WhereClause::TraitInScope { trait_name: t },
+    "Derefs" "(" <source:Ty> "," <target:Ty> ")" => WhereClause::Derefs { source, target },
 };
 
 QuantifiedWhereClause: QuantifiedWhereClause = {

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -50,5 +50,10 @@ error_chain! {
             description("could not match")
                 display("could not match")
         }
+
+        DuplicateLangItem(item: ir::LangItem) {
+            description("Duplicate lang item")
+                display("Duplicate lang item `{:?}`", item)
+        }
     }
 }

--- a/src/fold/mod.rs
+++ b/src/fold/mod.rs
@@ -425,7 +425,7 @@ enum_fold!(PolarizedTraitRef[] { Positive(a), Negative(a) });
 enum_fold!(ParameterKind[T,L] { Ty(a), Lifetime(a) } where T: Fold, L: Fold);
 enum_fold!(WhereClauseAtom[] { Implemented(a), ProjectionEq(a) });
 enum_fold!(DomainGoal[] { Holds(a), WellFormed(a), FromEnv(a), Normalize(a), UnselectedNormalize(a),
-                          WellFormedTy(a), FromEnvTy(a), InScope(a) });
+                          WellFormedTy(a), FromEnvTy(a), InScope(a), Deref(a) });
 enum_fold!(LeafGoal[] { EqGoal(a), DomainGoal(a) });
 enum_fold!(Constraint[] { LifetimeEq(a, b) });
 enum_fold!(Goal[] { Quantified(qkind, subgoal), Implies(wc, subgoal), And(g1, g2), Not(g),
@@ -571,6 +571,7 @@ struct_fold!(AssociatedTyValueBound { ty, where_clauses });
 struct_fold!(Environment { clauses });
 struct_fold!(InEnvironment[F] { environment, goal } where F: Fold<Result = F>);
 struct_fold!(EqGoal { a, b });
+struct_fold!(Deref { source, target });
 struct_fold!(ProgramClauseImplication {
     consequence,
     conditions,

--- a/src/fold/mod.rs
+++ b/src/fold/mod.rs
@@ -425,7 +425,7 @@ enum_fold!(PolarizedTraitRef[] { Positive(a), Negative(a) });
 enum_fold!(ParameterKind[T,L] { Ty(a), Lifetime(a) } where T: Fold, L: Fold);
 enum_fold!(WhereClauseAtom[] { Implemented(a), ProjectionEq(a) });
 enum_fold!(DomainGoal[] { Holds(a), WellFormed(a), FromEnv(a), Normalize(a), UnselectedNormalize(a),
-                          WellFormedTy(a), FromEnvTy(a), InScope(a), Deref(a) });
+                          WellFormedTy(a), FromEnvTy(a), InScope(a), Derefs(a) });
 enum_fold!(LeafGoal[] { EqGoal(a), DomainGoal(a) });
 enum_fold!(Constraint[] { LifetimeEq(a, b) });
 enum_fold!(Goal[] { Quantified(qkind, subgoal), Implies(wc, subgoal), And(g1, g2), Not(g),
@@ -571,7 +571,7 @@ struct_fold!(AssociatedTyValueBound { ty, where_clauses });
 struct_fold!(Environment { clauses });
 struct_fold!(InEnvironment[F] { environment, goal } where F: Fold<Result = F>);
 struct_fold!(EqGoal { a, b });
-struct_fold!(Deref { source, target });
+struct_fold!(Derefs { source, target });
 struct_fold!(ProgramClauseImplication {
     consequence,
     conditions,

--- a/src/ir/debug.rs
+++ b/src/ir/debug.rs
@@ -205,6 +205,7 @@ impl Debug for DomainGoal {
             DomainGoal::WellFormedTy(t) => write!(fmt, "WellFormed({:?})", t),
             DomainGoal::FromEnvTy(t) => write!(fmt, "FromEnv({:?})", t),
             DomainGoal::InScope(n) => write!(fmt, "InScope({:?})", n),
+            DomainGoal::Deref(n) => write!(fmt, "Deref({:?})", n),
         }
     }
 }

--- a/src/ir/debug.rs
+++ b/src/ir/debug.rs
@@ -205,7 +205,7 @@ impl Debug for DomainGoal {
             DomainGoal::WellFormedTy(t) => write!(fmt, "WellFormed({:?})", t),
             DomainGoal::FromEnvTy(t) => write!(fmt, "FromEnv({:?})", t),
             DomainGoal::InScope(n) => write!(fmt, "InScope({:?})", n),
-            DomainGoal::Deref(n) => write!(fmt, "Deref({:?})", n),
+            DomainGoal::Derefs(n) => write!(fmt, "Derefs({:?})", n),
         }
     }
 }

--- a/src/ir/mod.rs
+++ b/src/ir/mod.rs
@@ -464,7 +464,7 @@ pub enum WhereClauseAtom {
 }
 
 #[derive(Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Debug)]
-pub struct Deref {
+pub struct Derefs {
     pub source: Ty,
     pub target: Ty,
 }
@@ -532,13 +532,12 @@ pub enum DomainGoal {
 
     InScope(ItemId),
 
-    /// Whether a type can Deref into another. Right now this is just:
+    /// Whether a type can deref into another. Right now this is just:
     /// ```notrust
-    /// Deref(T, U) :- Implemented(T: Deref<Target = U>)
+    /// Derefs(T, U) :- Implemented(T: Deref<Target = U>)
     /// ```
-    /// In Rust there are also raw pointers which can be deref'd
-    /// but do not implement Deref.
-    Deref(Deref)
+    /// In Rust there are also raw pointers which can be deref'd but do not implement Deref.
+    Derefs(Derefs)
 }
 
 pub type QuantifiedDomainGoal = Binders<DomainGoal>;

--- a/src/ir/mod.rs
+++ b/src/ir/mod.rs
@@ -38,6 +38,9 @@ pub struct Program {
 
     /// For each user-specified clause
     crate custom_clauses: Vec<ProgramClause>,
+
+    /// Special types and traits.
+    crate lang_items: BTreeMap<LangItem, ItemId>,
 }
 
 impl Program {
@@ -69,6 +72,11 @@ pub struct ProgramEnvironment {
 
     /// Compiled forms of the above:
     crate program_clauses: Vec<ProgramClause>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub enum LangItem {
+    DerefTrait,
 }
 
 #[derive(Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
@@ -244,6 +252,7 @@ pub struct TraitFlags {
     crate auto: bool,
     crate marker: bool,
     crate external: bool,
+    pub deref: bool,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]

--- a/src/ir/mod.rs
+++ b/src/ir/mod.rs
@@ -454,6 +454,12 @@ pub enum WhereClauseAtom {
     ProjectionEq(ProjectionEq),
 }
 
+#[derive(Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Debug)]
+pub struct Deref {
+    pub source: Ty,
+    pub target: Ty,
+}
+
 /// A "domain goal" is a goal that is directly about Rust, rather than a pure
 /// logical statement. As much as possible, the Chalk solver should avoid
 /// decomposing this enum, and instead treat its values opaquely.
@@ -516,6 +522,14 @@ pub enum DomainGoal {
     FromEnvTy(Ty),
 
     InScope(ItemId),
+
+    /// Whether a type can Deref into another. Right now this is just:
+    /// ```notrust
+    /// Deref(T, U) :- Implemented(T: Deref<Target = U>)
+    /// ```
+    /// In Rust there are also raw pointers which can be deref'd
+    /// but do not implement Deref.
+    Deref(Deref)
 }
 
 pub type QuantifiedDomainGoal = Binders<DomainGoal>;

--- a/src/lower/test.rs
+++ b/src/lower/test.rs
@@ -855,14 +855,14 @@ fn higher_ranked_cyclic_requirements() {
 fn deref_trait() {
     lowering_success! {
         program {
-            #[deref] trait Deref { type Target; }
+            #[lang_deref] trait Deref { type Target; }
         }
     }
 
     lowering_error! {
         program {
-            #[deref] trait Deref { }
-            #[deref] trait DerefDupe { }
+            #[lang_deref] trait Deref { }
+            #[lang_deref] trait DerefDupe { }
         } error_msg {
             "Duplicate lang item `DerefTrait`"
         }

--- a/src/lower/test.rs
+++ b/src/lower/test.rs
@@ -850,3 +850,21 @@ fn higher_ranked_cyclic_requirements() {
         }
     }
 }
+
+#[test]
+fn deref_trait() {
+    lowering_success! {
+        program {
+            #[deref] trait Deref { type Target; }
+        }
+    }
+
+    lowering_error! {
+        program {
+            #[deref] trait Deref { }
+            #[deref] trait DerefDupe { }
+        } error_msg {
+            "Duplicate lang item `DerefTrait`"
+        }
+    }
+}

--- a/src/lower/wf.rs
+++ b/src/lower/wf.rs
@@ -138,7 +138,8 @@ impl FoldInputTypes for DomainGoal {
             DomainGoal::WellFormed(..) |
             DomainGoal::FromEnv(..) |
             DomainGoal::WellFormedTy(..) |
-            DomainGoal::FromEnvTy(..) => panic!("unexpected where clause"),
+            DomainGoal::FromEnvTy(..) |
+            DomainGoal::Deref(..) => panic!("unexpected where clause"),
 
             DomainGoal::InScope(..) => (),
         }

--- a/src/lower/wf.rs
+++ b/src/lower/wf.rs
@@ -139,7 +139,7 @@ impl FoldInputTypes for DomainGoal {
             DomainGoal::FromEnv(..) |
             DomainGoal::WellFormedTy(..) |
             DomainGoal::FromEnvTy(..) |
-            DomainGoal::Deref(..) => panic!("unexpected where clause"),
+            DomainGoal::Derefs(..) => panic!("unexpected where clause"),
 
             DomainGoal::InScope(..) => (),
         }

--- a/src/solve/test/mod.rs
+++ b/src/solve/test/mod.rs
@@ -2058,3 +2058,52 @@ fn higher_ranked_implied_bounds() {
         }
     }
 }
+
+#[test]
+fn deref_goal() {
+    test! {
+        program {
+            #[lang_deref]
+            trait Deref { type Target; }
+            struct Foo { }
+            struct Bar { }
+            struct Baz { }
+            impl Deref for Foo { type Target = Bar; }
+        }
+
+        goal {
+            Derefs(Foo, Bar)
+        } yields {
+            "Unique"
+        }
+
+        goal {
+            Derefs(Foo, Baz)
+        } yields {
+            "No possible solution"
+        }
+    }
+    
+    test! {
+        program {
+            #[lang_deref]
+            trait Deref { type Target; }
+            struct Arc<T> { }
+            struct i32 { }
+            struct u64 { }
+            impl<T> Deref for Arc<T> { type Target = T; }
+        }
+
+        goal {
+            Derefs(Arc<i32>, i32)
+        } yields {
+            "Unique"
+        }
+
+        goal {
+            Derefs(Arc<i32>, u64)
+        } yields {
+            "No possible solution"
+        }
+    }
+}

--- a/src/zip.rs
+++ b/src/zip.rs
@@ -182,7 +182,7 @@ struct_zip!(ProjectionEq { projection, ty });
 struct_zip!(UnselectedNormalize { projection, ty });
 struct_zip!(EqGoal { a, b });
 struct_zip!(ProgramClauseImplication { consequence, conditions });
-struct_zip!(Deref { source, target });
+struct_zip!(Derefs { source, target });
 
 impl Zip for Environment {
     fn zip_with<Z: Zipper>(zipper: &mut Z, a: &Self, b: &Self) -> Fallible<()> {
@@ -226,7 +226,7 @@ enum_zip!(DomainGoal {
     WellFormedTy,
     FromEnvTy,
     InScope,
-    Deref
+    Derefs
 });
 enum_zip!(LeafGoal { DomainGoal, EqGoal });
 enum_zip!(ProgramClause { Implies, ForAll });

--- a/src/zip.rs
+++ b/src/zip.rs
@@ -182,6 +182,7 @@ struct_zip!(ProjectionEq { projection, ty });
 struct_zip!(UnselectedNormalize { projection, ty });
 struct_zip!(EqGoal { a, b });
 struct_zip!(ProgramClauseImplication { consequence, conditions });
+struct_zip!(Deref { source, target });
 
 impl Zip for Environment {
     fn zip_with<Z: Zipper>(zipper: &mut Z, a: &Self, b: &Self) -> Fallible<()> {
@@ -225,6 +226,7 @@ enum_zip!(DomainGoal {
     WellFormedTy,
     FromEnvTy,
     InScope,
+    Deref
 });
 enum_zip!(LeafGoal { DomainGoal, EqGoal });
 enum_zip!(ProgramClause { Implies, ForAll });


### PR DESCRIPTION
This add the `Derefs(T, U)` domain goal, which is true if `T` can be directly derefed to `U`, so that derefs can be represented as a first-class thing in chalk. This PR basically enables this:
```rust
test! {
    program {
         #[lang_deref]
         trait Deref { type Target; }
         struct Foo { }
         struct Bar { }
         impl Deref for Foo { type Target = Bar; }
     }
    
     goal {
           Derefs(Foo, Bar)
      } yields {
           "Unique"
     }
}
```

This is done by adding the rule `forall<T, U> { Deref(T, U) :- Implemented(T: Deref<Target = U>) }` in program lowering.

Part of #105.