### PR TITLE
Raw pointer deref.

### DIFF
--- a/chalk-parse/src/ast.rs
+++ b/chalk-parse/src/ast.rs
@@ -175,7 +175,10 @@ pub enum Ty {
     ForAll {
         lifetime_names: Vec<Identifier>,
         ty: Box<Ty>
-    }
+    },
+    RawPtr {
+        ty: Box<Ty>
+    },
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]

--- a/chalk-parse/src/parser.lalrpop
+++ b/chalk-parse/src/parser.lalrpop
@@ -40,6 +40,8 @@ AutoKeyword: () = "#" "[" "auto" "]";
 MarkerKeyword: () = "#" "[" "marker" "]";
 DerefLangItem: () = "#" "[" "lang_deref" "]";
 FundamentalKeyword: () = "#" "[" "fundamental" "]";
+ConstKeyword: () = "const";
+MutKeyword: () = "mut";
 
 StructDefn: StructDefn = {
     <fundamental:FundamentalKeyword?> <external:ExternalKeyword?> "struct" <n:Id><p:Angle<ParameterKind>>
@@ -150,6 +152,8 @@ pub Ty: Ty = {
         lifetime_names: l,
         ty: Box::new(t)
     },
+    "*" ConstKeyword <t:Ty> => Ty::RawPtr { ty: Box::new(t) },
+    "*" MutKeyword <t:Ty> => Ty::RawPtr { ty: Box::new(t) },
     TyWithoutFor,
 };
 

--- a/src/fold.rs
+++ b/src/fold.rs
@@ -266,7 +266,7 @@ crate fn super_fold_ty(folder: &mut dyn Folder, ty: &Ty, binders: usize) -> Fall
                     folder.fold_free_universal_ty(ui, binders)
                 }
 
-                TypeName::ItemId(_) | TypeName::AssociatedType(_) => {
+                TypeName::ItemId(_) | TypeName::AssociatedType(_) | TypeName::RawPtr => {
                     let parameters = parameters.fold_with(folder, binders)?;
                     Ok(ApplicationTy { name, parameters }.cast())
                 }

--- a/src/ir/debug.rs
+++ b/src/ir/debug.rs
@@ -39,6 +39,7 @@ impl Debug for TypeName {
             TypeName::ItemId(id) => write!(fmt, "{:?}", id),
             TypeName::ForAll(universe) => write!(fmt, "!{}", universe.counter),
             TypeName::AssociatedType(assoc_ty) => write!(fmt, "{:?}", assoc_ty),
+            TypeName::RawPtr => write!(fmt, "*const"),
         }
     }
 }

--- a/src/ir/lowering.rs
+++ b/src/ir/lowering.rs
@@ -872,6 +872,13 @@ impl LowerTy for Ty {
                 };
                 Ok(ir::Ty::ForAll(Box::new(quantified_ty)))
             }
+
+            Ty::RawPtr {
+                ref ty
+            } => Ok(ir::Ty::Apply(ir::ApplicationTy {
+                    name: ir::TypeName::RawPtr,
+                    parameters: vec![ty.lower(env)?.cast()],
+                }))
         }
     }
 }

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -34,30 +34,37 @@ impl Program {
         );
         program_clauses.extend(self.default_impl_data.iter().map(|d| d.to_program_clause()));
 
-        // Adds clause that defines the Derefs domain goal:
-        // forall<T, U> { Derefs(T, U) :- ProjectionEq(<T as Deref>::Target = U>) }
+        // Add clauses that define the Derefs domain goal.
+        // forall<T, U> {
+        //  Derefs(T, U) :- ProjectionEq(<T as Deref>::Target = U>)
+        //  Derefs(T, U) :- T == *const/mut U
+        // }
+        let t = || Ty::Var(0);
+        let u = || Ty::Var(1);
         if let Some(trait_id) = self.lang_items.get(&LangItem::DerefTrait) {
             // Find `Deref::Target`.
             let associated_ty_id = self.associated_ty_data.values()
                                                         .find(|d| d.trait_id == *trait_id)
                                                         .expect("Deref has no assoc item")
                                                         .id;
-            let t = || Ty::Var(0);
-            let u = || Ty::Var(1);
-            program_clauses.push(Binders {
-                binders: vec![ParameterKind::Ty(()), ParameterKind::Ty(())],
-                value: ProgramClauseImplication {
-                    consequence: DomainGoal::Derefs(Derefs { source: t(), target: u() }),
-                    conditions: vec![ProjectionEq {
-                        projection: ProjectionTy {
-                            associated_ty_id,
-                            parameters: vec![t().cast()]
-                        },
-                        ty: u(),
-                    }.cast()]
+            // ProjectionEq(<T as Deref>::Target = U)
+            let g: Goal = ProjectionEq {
+                projection: ProjectionTy { 
+                    associated_ty_id,
+                    parameters: vec![t().cast()]
                 },
-            }.cast());
+                ty: u(),
+            }.cast();
+            program_clauses.push(g.imply_deref());
         }
+        let g: Goal = EqGoal {
+                a: t().cast(),
+                b: ApplicationTy {
+                    name: TypeName::RawPtr,
+                    parameters: vec![u().cast()],
+                }.cast().cast()
+            }.cast();
+        program_clauses.push(g.imply_deref());
 
         for datum in self.impl_data.values() {
             // If we encounter a negative impl, do not generate any rule. Negative impls

--- a/src/solve/test.rs
+++ b/src/solve/test.rs
@@ -2478,6 +2478,38 @@ fn deref_goal() {
             "No possible solution"
         }
     }
+
+    // Test raw ptr deref.
+    test! {
+        program {
+            struct i32 { }
+            struct u64 { }
+        }
+
+        goal {
+            Derefs(*const i32, i32)
+        } yields {
+            "Unique"
+        }
+
+        goal {
+            Derefs(*mut u64, u64)
+        } yields {
+            "Unique"
+        }
+
+        goal {
+            Derefs(*const *const i32, *const i32)
+        } yields {
+            "Unique"
+        }
+
+        goal {
+            Derefs(i32, u64)
+        } yields {
+           "No possible solution"
+        }
+    }
 }
 
 #[test]


### PR DESCRIPTION
Introduce `*mut` and `*const` to the parser which for now are semantically equivalent. Add fact `Derefs(T, U) :- T == *const/mut U`. Part of #105.