### PR TITLE
Implement GATs, step 1

### DIFF
--- a/chalk-parse/src/ast.rs
+++ b/chalk-parse/src/ast.rs
@@ -54,7 +54,7 @@ pub struct TraitFlags {
 pub struct AssocTyDefn {
     pub name: Identifier,
     pub parameter_kinds: Vec<ParameterKind>,
-    pub bounds: Vec<TraitBound>,
+    pub bounds: Vec<InlineBound>,
     pub where_clauses: Vec<QuantifiedWhereClause>,
 }
 
@@ -68,20 +68,23 @@ pub enum Parameter {
     Lifetime(Lifetime),
 }
 
+/// An inline bound, e.g. `: Foo<K>` in `impl<K, T: Foo<K>> SomeType<T>`.
+pub enum InlineBound {
+    TraitBound(TraitBound),
+    ProjectionEqBound(ProjectionEqBound),
+}
+
 /// Represents a trait bound on e.g. a type or type parameter.
 /// Does not know anything about what it's binding.
 pub struct TraitBound {
     pub trait_name: Identifier,
-    pub args_no_self: Vec<TraitBoundParameter>,
+    pub args_no_self: Vec<Parameter>,
 }
 
-pub enum TraitBoundParameter {
-    Ty(Ty),
-    Lifetime(Lifetime),
-    ProjectionEq(ProjectionEqBound),
-}
-
+/// Represents a projection equality bound on e.g. a type or type parameter.
+/// Does not know anything about what it's binding.
 pub struct ProjectionEqBound {
+    pub trait_bound: TraitBound,
     pub name: Identifier,
     pub parameters: Vec<Parameter>,
     pub value: Ty,

--- a/chalk-parse/src/ast.rs
+++ b/chalk-parse/src/ast.rs
@@ -54,7 +54,7 @@ pub struct TraitFlags {
 pub struct AssocTyDefn {
     pub name: Identifier,
     pub parameter_kinds: Vec<ParameterKind>,
-    pub bound: Option<TraitRef>,
+    pub bounds: Vec<TraitBound>,
     pub where_clauses: Vec<QuantifiedWhereClause>,
 }
 
@@ -175,6 +175,11 @@ impl PolarizedTraitRef {
             PolarizedTraitRef::Negative(trait_ref)
         }
     }
+}
+
+pub struct TraitBound {
+    pub trait_name: Identifier,
+    pub args_no_self: Vec<Parameter>,
 }
 
 #[derive(Copy, Clone, Debug)]

--- a/chalk-parse/src/ast.rs
+++ b/chalk-parse/src/ast.rs
@@ -68,6 +68,25 @@ pub enum Parameter {
     Lifetime(Lifetime),
 }
 
+/// Represents a trait bound on e.g. a type or type parameter.
+/// Does not know anything about what it's binding.
+pub struct TraitBound {
+    pub trait_name: Identifier,
+    pub args_no_self: Vec<TraitBoundParameter>,
+}
+
+pub enum TraitBoundParameter {
+    Ty(Ty),
+    Lifetime(Lifetime),
+    ProjectionEq(ProjectionEqBound),
+}
+
+pub struct ProjectionEqBound {
+    pub name: Identifier,
+    pub parameters: Vec<Parameter>,
+    pub value: Ty,
+}
+
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum Kind {
     Ty,
@@ -175,11 +194,6 @@ impl PolarizedTraitRef {
             PolarizedTraitRef::Negative(trait_ref)
         }
     }
-}
-
-pub struct TraitBound {
-    pub trait_name: Identifier,
-    pub args_no_self: Vec<Parameter>,
 }
 
 #[derive(Copy, Clone, Debug)]

--- a/chalk-parse/src/ast.rs
+++ b/chalk-parse/src/ast.rs
@@ -54,6 +54,8 @@ pub struct TraitFlags {
 pub struct AssocTyDefn {
     pub name: Identifier,
     pub parameter_kinds: Vec<ParameterKind>,
+    pub bound: Option<TraitRef>,
+    pub where_clauses: Vec<QuantifiedWhereClause>,
 }
 
 pub enum ParameterKind {

--- a/chalk-parse/src/ast.rs
+++ b/chalk-parse/src/ast.rs
@@ -115,7 +115,6 @@ pub struct Impl {
 pub struct AssocTyValue {
     pub name: Identifier,
     pub parameter_kinds: Vec<ParameterKind>,
-    pub where_clauses: Vec<WhereClause>,
     pub value: Ty,
 }
 

--- a/chalk-parse/src/parser.lalrpop
+++ b/chalk-parse/src/parser.lalrpop
@@ -72,9 +72,26 @@ TraitDefn: TraitDefn = {
 };
 
 AssocTyDefn: AssocTyDefn = {
-    "type" <name:Id> <p:Angle<ParameterKind>> ";" => AssocTyDefn {
-        name: name,
-        parameter_kinds: p
+    "type" <name:Id> <p:Angle<ParameterKind>> <b:(":" <Id> <Angle<Parameter>>)?>
+        <w:QuantifiedWhereClauses> ";" =>
+    {
+        let bound = match b {
+            Some((t, a)) => {
+                let mut args = vec![Parameter::Ty(Ty::Id{ name })];
+                args.extend(a);
+                Some(TraitRef {
+                    trait_name: t,
+                    args: args,
+                })
+            }
+            None => None
+        };
+        AssocTyDefn {
+            name: name,
+            parameter_kinds: p,
+            where_clauses: w,
+            bound,
+        }
     }
 };
 

--- a/chalk-parse/src/parser.lalrpop
+++ b/chalk-parse/src/parser.lalrpop
@@ -102,11 +102,10 @@ ParameterKind: ParameterKind = {
 };
 
 AssocTyValue: AssocTyValue = {
-    "type" <n:Id> <a:Angle<ParameterKind>> <wc:WhereClauses> "=" <v:Ty> ";" => AssocTyValue {
+    "type" <n:Id> <a:Angle<ParameterKind>> "=" <v:Ty> ";" => AssocTyValue {
         name: n,
         parameter_kinds: a,
         value: v,
-        where_clauses: wc,
     },
 };
 
@@ -199,11 +198,6 @@ InlineClause: Clause = {
         consequence: c.consequence,
         conditions: c.conditions,
     }
-};
-
-WhereClauses: Vec<WhereClause> = {
-    "where" <Comma<WhereClause>>,
-    () => vec![],
 };
 
 QuantifiedWhereClauses: Vec<QuantifiedWhereClause> = {

--- a/chalk-parse/src/parser.lalrpop
+++ b/chalk-parse/src/parser.lalrpop
@@ -72,7 +72,7 @@ TraitDefn: TraitDefn = {
 };
 
 AssocTyDefn: AssocTyDefn = {
-    "type" <name:Id> <p:Angle<ParameterKind>> <b:(":" <Plus<TraitBound>>)?>
+    "type" <name:Id> <p:Angle<ParameterKind>> <b:(":" <Plus<InlineBound>>)?>
         <w:QuantifiedWhereClauses> ";" =>
     {
         AssocTyDefn {
@@ -84,8 +84,13 @@ AssocTyDefn: AssocTyDefn = {
     }
 };
 
+InlineBound: InlineBound = {
+    TraitBound => InlineBound::TraitBound(<>),
+    ProjectionEqBound => InlineBound::ProjectionEqBound(<>),
+};
+
 TraitBound: TraitBound = {
-    <t:Id> <a:Angle<TraitBoundParameter>> => {
+    <t:Id> <a:Angle<Parameter>> => {
         TraitBound {
             trait_name: t,
             args_no_self: a,
@@ -93,16 +98,18 @@ TraitBound: TraitBound = {
     }
 };
 
-TraitBoundParameter: TraitBoundParameter = {
-    Ty => TraitBoundParameter::Ty(<>),
-    Lifetime => TraitBoundParameter::Lifetime(<>),
-    ProjectionEqBound => TraitBoundParameter::ProjectionEq(<>),
-};
-
 ProjectionEqBound: ProjectionEqBound = {
-    <name:Id> <parameters:Angle<Parameter>> "=" <value:Ty> => ProjectionEqBound {
-        name, parameters, value
-    },
+    <t:Id> "<" <a:(<Comma<Parameter>> ",")?> <name:Id> <a2:Angle<Parameter>>
+        "=" <ty:Ty> ">" => ProjectionEqBound
+    {
+        trait_bound: TraitBound {
+            trait_name: t,
+            args_no_self: a.unwrap_or(vec![]),
+        },
+        name,
+        parameters: a2,
+        value: ty,
+    }
 };
 
 Impl: Impl = {

--- a/chalk-parse/src/parser.lalrpop
+++ b/chalk-parse/src/parser.lalrpop
@@ -72,25 +72,23 @@ TraitDefn: TraitDefn = {
 };
 
 AssocTyDefn: AssocTyDefn = {
-    "type" <name:Id> <p:Angle<ParameterKind>> <b:(":" <Id> <Angle<Parameter>>)?>
+    "type" <name:Id> <p:Angle<ParameterKind>> <b:(":" <Plus<TraitBound>>)?>
         <w:QuantifiedWhereClauses> ";" =>
     {
-        let bound = match b {
-            Some((t, a)) => {
-                let mut args = vec![Parameter::Ty(Ty::Id{ name })];
-                args.extend(a);
-                Some(TraitRef {
-                    trait_name: t,
-                    args: args,
-                })
-            }
-            None => None
-        };
         AssocTyDefn {
             name: name,
             parameter_kinds: p,
             where_clauses: w,
-            bound,
+            bounds: b.unwrap_or(vec![]),
+        }
+    }
+};
+
+TraitBound: TraitBound = {
+    <t:Id> <a:Angle<Parameter>> => {
+        TraitBound {
+            trait_name: t,
+            args_no_self: a,
         }
     }
 };
@@ -299,6 +297,11 @@ Comma<T>: Vec<T> = {
 #[inline]
 SemiColon<T>: Vec<T> = {
     <Separator<";", T>>
+};
+
+#[inline]
+Plus<T>: Vec<T> = {
+    <Separator<"+", T>>
 };
 
 Angle<T>: Vec<T> = {

--- a/chalk-parse/src/parser.lalrpop
+++ b/chalk-parse/src/parser.lalrpop
@@ -85,12 +85,24 @@ AssocTyDefn: AssocTyDefn = {
 };
 
 TraitBound: TraitBound = {
-    <t:Id> <a:Angle<Parameter>> => {
+    <t:Id> <a:Angle<TraitBoundParameter>> => {
         TraitBound {
             trait_name: t,
             args_no_self: a,
         }
     }
+};
+
+TraitBoundParameter: TraitBoundParameter = {
+    Ty => TraitBoundParameter::Ty(<>),
+    Lifetime => TraitBoundParameter::Lifetime(<>),
+    ProjectionEqBound => TraitBoundParameter::ProjectionEq(<>),
+};
+
+ProjectionEqBound: ProjectionEqBound = {
+    <name:Id> <parameters:Angle<Parameter>> "=" <value:Ty> => ProjectionEqBound {
+        name, parameters, value
+    },
 };
 
 Impl: Impl = {

--- a/src/fold/mod.rs
+++ b/src/fold/mod.rs
@@ -567,7 +567,7 @@ struct_fold!(AssociatedTyValue {
     associated_ty_id,
     value,
 });
-struct_fold!(AssociatedTyValueBound { ty, where_clauses });
+struct_fold!(AssociatedTyValueBound { ty });
 struct_fold!(Environment { clauses });
 struct_fold!(InEnvironment[F] { environment, goal } where F: Fold<Result = F>);
 struct_fold!(EqGoal { a, b });

--- a/src/ir/lowering/mod.rs
+++ b/src/ir/lowering/mod.rs
@@ -872,7 +872,6 @@ impl LowerAssocTyValue for AssocTyValue {
         let value = env.in_binders(self.all_parameters(), |env| {
             Ok(ir::AssociatedTyValueBound {
                 ty: self.value.lower(env)?,
-                where_clauses: self.where_clauses.lower(env)?,
             })
         })?;
         Ok(ir::AssociatedTyValue {

--- a/src/ir/lowering/test.rs
+++ b/src/ir/lowering/test.rs
@@ -302,3 +302,34 @@ fn check_parameter_kinds() {
         }
     }
 }
+
+#[test]
+fn gat_parse() {
+    let program = Arc::new(
+        parse_and_lower_program(
+            "
+            trait Sized {}
+
+            trait Foo {
+                type Item<'a, T>: Clone where Self: Sized;
+            }
+
+            trait Bar {
+                type Item<'a, T> where Self: Sized;
+            }
+
+            trait Baz {
+                type Item<'a, T>: Clone;
+            }
+
+            trait Quux {
+                type Item<'a, T>;
+            }
+            ",
+            SolverChoice::slg()
+        ).unwrap()
+    );
+    tls::set_current_program(&program, || {
+        println!("{:#?}", program.associated_ty_data.values());
+    });
+}

--- a/src/ir/lowering/test.rs
+++ b/src/ir/lowering/test.rs
@@ -211,8 +211,7 @@ fn atc_accounting() {
             AssociatedTyValue {
                 associated_ty_id: (Iterable::Iter),
                 value: for<lifetime> AssociatedTyValueBound {
-                    ty: Iter<'?0, ?1>,
-                    where_clauses: []
+                    ty: Iter<'?0, ?1>
                 }
             }
         ],

--- a/src/ir/lowering/test.rs
+++ b/src/ir/lowering/test.rs
@@ -318,8 +318,12 @@ fn gat_parse() {
                 type Item<'a, T> where Self: Sized;
             }
 
+            struct Container<T> {
+                value: T
+            }
+
             trait Baz {
-                type Item<'a, T>: Clone;
+                type Item<'a, 'b, T>: Foo<Item<'b, T> = Containter<T>> + Clone;
             }
 
             trait Quux {

--- a/src/ir/lowering/test.rs
+++ b/src/ir/lowering/test.rs
@@ -311,7 +311,7 @@ fn gat_parse() {
             trait Sized {}
 
             trait Foo {
-                type Item<'a, T>: Clone where Self: Sized;
+                type Item<'a, T>: Sized + Clone where Self: Sized;
             }
 
             trait Bar {

--- a/src/ir/mod.rs
+++ b/src/ir/mod.rs
@@ -289,10 +289,6 @@ pub struct AssociatedTyValue {
 pub struct AssociatedTyValueBound {
     /// Type that we normalize to. The X in `type Foo<'a> = X`.
     crate ty: Ty,
-
-    /// Where-clauses that must hold for projection to be valid. The
-    /// WC in `type Foo<'a> = X where WC`.
-    crate where_clauses: Vec<DomainGoal>,
 }
 
 #[derive(Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]

--- a/src/ir/mod.rs
+++ b/src/ir/mod.rs
@@ -273,8 +273,10 @@ pub struct AssociatedTyDatum {
     /// but possibly including more.
     crate parameter_kinds: Vec<ParameterKind<Identifier>>,
 
+    // FIXME: inline bounds on the associated ty need to be implemented
+
     /// Where clauses that must hold for the projection be well-formed.
-    crate where_clauses: Vec<DomainGoal>,
+    crate where_clauses: Vec<QuantifiedDomainGoal>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,13 +3,11 @@
 #![feature(catch_expr)]
 #![feature(crate_in_paths)]
 #![feature(crate_visibility_modifier)]
-#![feature(dyn_trait)]
 #![feature(in_band_lifetimes)]
 #![feature(macro_at_most_once_rep)]
 #![feature(macro_vis_matcher)]
 #![feature(specialization)]
 #![feature(step_trait)]
-#![feature(underscore_lifetimes)]
 
 extern crate chalk_parse;
 #[macro_use]

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -200,10 +200,7 @@ impl ir::AssociatedTyValue {
             .trait_ref
             .trait_ref()
             .up_shift(self.value.len());
-        let conditions: Vec<ir::Goal> = Some(impl_trait_ref.clone().cast())
-            .into_iter()
-            .chain(self.value.value.where_clauses.clone().cast())
-            .collect();
+        let conditions: Vec<ir::Goal> = vec![impl_trait_ref.clone().cast()];
 
         // Bound parameters + `Self` type of the trait-ref
         let parameters: Vec<_> = {


### PR DESCRIPTION
This adds parsing rules for bounds and where clauses on associated type definitions for #116.

It also removes where clauses on associated type values.

The way I handled bounds directly in the parser felt a bit messy, open to suggestions. Not sure if using the associated type name directly in the `TraitRef` is going to work downstream.