### PR TITLE
Fewer engine traits

### DIFF
--- a/chalk-engine/src/context/mod.rs
+++ b/chalk-engine/src/context/mod.rs
@@ -91,7 +91,7 @@ pub trait InferenceContext<C: Context>: ExClauseContext<C> {
 
     /// The successful result from unification: contains new subgoals
     /// and things that can be attached to an ex-clause.
-    type UnificationResult: UnificationResult<C, Self>;
+    type UnificationResult;
 
     fn goal_in_environment(environment: &Self::Environment, goal: Self::Goal) -> Self::GoalInEnvironment;
     
@@ -110,6 +110,10 @@ pub trait InferenceContext<C: Context>: ExClauseContext<C> {
     /// `HhGoal`, but the goals contained within are left as context
     /// goals.
     fn into_hh_goal(goal: Self::Goal) -> HhGoal<C, Self>;
+
+    /// Add the residual subgoals as new subgoals of the ex-clause.
+    /// Also add region constraints.
+    fn into_ex_clause(result: Self::UnificationResult, ex_clause: &mut ExClause<C, Self>);
 }
 
 pub trait ContextOps<C: Context> {
@@ -328,15 +332,6 @@ pub trait UniverseMap<C: Context>: Clone + Debug {
         &self,
         value: &C::CanonicalConstrainedSubst,
     ) -> C::CanonicalConstrainedSubst;
-}
-
-/// Embodies the result of a unification operation: we presume that
-/// unification may produce new residual subgoals, which must be
-/// further proven, as well as region constraints.
-pub trait UnificationResult<C: Context, I: InferenceContext<C>> {
-    /// Add the residual subgoals as new subgoals of the ex-clause.
-    /// Also add region constraints.
-    fn into_ex_clause(self, ex_clause: &mut ExClause<C, I>);
 }
 
 pub trait AnswerStream<C: Context> {

--- a/chalk-engine/src/context/mod.rs
+++ b/chalk-engine/src/context/mod.rs
@@ -8,7 +8,7 @@ crate mod prelude;
 
 /// The "context" in which the SLG solver operates.
 pub trait Context: Sized + Clone + Debug + ContextOps<Self> + AggregateOps<Self> {
-    type CanonicalExClause: CanonicalExClause<Self>;
+    type CanonicalExClause: Debug;
 
     /// A map between universes. These are produced when
     /// u-canonicalizing something; they map canonical results back to
@@ -41,6 +41,10 @@ pub trait Context: Sized + Clone + Debug + ContextOps<Self> + AggregateOps<Self>
     /// completely opaque to the SLG solver; it is produced by
     /// `make_solution`.
     type Solution;
+
+    /// Extracts the inner normalized substitution.
+    fn inference_normalized_subst(canon_ex_clause: &Self::CanonicalExClause)
+                                  -> &Self::InferenceNormalizedSubst;
 }
 
 pub trait ExClauseContext<C: Context>: Sized + Debug {
@@ -300,11 +304,6 @@ pub trait ResolventOps<C: Context, I: InferenceContext<C>> {
         answer_table_goal: &C::CanonicalGoalInEnvironment,
         canonical_answer_subst: &C::CanonicalConstrainedSubst,
     ) -> Fallible<ExClause<C, I>>;
-}
-
-pub trait CanonicalExClause<C: Context>: Debug {
-    /// Extracts the inner normalized substitution.
-    fn inference_normalized_subst(&self) -> &C::InferenceNormalizedSubst;
 }
 
 pub trait CanonicalConstrainedSubst<C: Context>: Clone + Debug + Eq + Hash + Ord {

--- a/chalk-engine/src/context/mod.rs
+++ b/chalk-engine/src/context/mod.rs
@@ -69,7 +69,7 @@ pub trait InferenceContext<C: Context>: ExClauseContext<C> {
     /// A goal that can be targeted by a program clause. The SLG
     /// solver treats these opaquely; in contrast, it understands
     /// "meta" goals like `G1 && G2` and so forth natively.
-    type DomainGoal: DomainGoal<C, Self>;
+    type DomainGoal: Debug;
 
     /// A "higher-order" goal, quantified over some types and/or
     /// lifetimes. When you have a quantification, like `forall<T> { G
@@ -94,6 +94,9 @@ pub trait InferenceContext<C: Context>: ExClauseContext<C> {
     type UnificationResult: UnificationResult<C, Self>;
 
     fn goal_in_environment(environment: &Self::Environment, goal: Self::Goal) -> Self::GoalInEnvironment;
+    
+    /// Upcast this domain goal into a more general goal.
+    fn into_goal(domain_goal: Self::DomainGoal) -> Self::Goal;
 }
 
 pub trait ContextOps<C: Context> {
@@ -293,11 +296,6 @@ pub trait CanonicalConstrainedSubst<C: Context>: Clone + Debug + Eq + Hash + Ord
 
     /// Extracts the inner normalized substitution.
     fn inference_normalized_subst(&self) -> &C::InferenceNormalizedSubst;
-}
-
-pub trait DomainGoal<C: Context, I: InferenceContext<C>>: Debug {
-    /// Upcast this domain goal into a more general goal.
-    fn into_goal(self) -> I::Goal;
 }
 
 pub trait Goal<C: Context, I: InferenceContext<C>>: Clone + Debug + Eq {

--- a/chalk-engine/src/context/mod.rs
+++ b/chalk-engine/src/context/mod.rs
@@ -43,10 +43,23 @@ pub trait Context: Sized + Clone + Debug + ContextOps<Self> + AggregateOps<Self>
     type Solution;
 }
 
+pub trait ExClauseContext<C: Context>: Sized + Debug {
+    /// Represents a substitution from the "canonical variables" found
+    /// in a canonical goal to specific values.
+    type Substitution: Debug;
+
+    /// Represents a region constraint that will be propagated back
+    /// (but not verified).
+    type RegionConstraint: Debug;
+
+    /// Represents a goal along with an environment.
+    type GoalInEnvironment: Debug + Clone + Eq + Ord + Hash;
+}
+
 /// The set of types belonging to an "inference context"; in rustc,
 /// these types are tied to the lifetime of the arena within which an
 /// inference context operates.
-pub trait InferenceContext<C: Context>: Sized + Debug {
+pub trait InferenceContext<C: Context>: ExClauseContext<C> {
     /// Represents a set of hypotheses that are assumed to be true.
     type Environment: Environment<C, Self>;
 
@@ -57,17 +70,6 @@ pub trait InferenceContext<C: Context>: Sized + Debug {
     /// solver treats these opaquely; in contrast, it understands
     /// "meta" goals like `G1 && G2` and so forth natively.
     type DomainGoal: DomainGoal<C, Self>;
-
-    /// Represents a goal along with an environment.
-    type GoalInEnvironment: Debug + Clone + Eq + Ord + Hash;
-
-    /// Represents a region constraint that will be propagated back
-    /// (but not verified).
-    type RegionConstraint: Debug;
-
-    /// Represents a substitution from the "canonical variables" found
-    /// in a canonical goal to specific values.
-    type Substitution: Debug;
 
     /// A "higher-order" goal, quantified over some types and/or
     /// lifetimes. When you have a quantification, like `forall<T> { G

--- a/chalk-engine/src/context/mod.rs
+++ b/chalk-engine/src/context/mod.rs
@@ -61,7 +61,7 @@ pub trait ExClauseContext<C: Context>: Sized + Debug {
 /// inference context operates.
 pub trait InferenceContext<C: Context>: ExClauseContext<C> {
     /// Represents a set of hypotheses that are assumed to be true.
-    type Environment: Environment<C, Self>;
+    type Environment: Debug + Clone;
 
     /// Goals correspond to things we can prove.
     type Goal: Clone + Debug + Eq;
@@ -114,6 +114,11 @@ pub trait InferenceContext<C: Context>: ExClauseContext<C> {
     /// Add the residual subgoals as new subgoals of the ex-clause.
     /// Also add region constraints.
     fn into_ex_clause(result: Self::UnificationResult, ex_clause: &mut ExClause<C, Self>);
+
+    // Used by: simplify
+    fn add_clauses(env: &Self::Environment,
+                  clauses: impl IntoIterator<Item = Self::ProgramClause>)
+                  -> Self::Environment;
 }
 
 pub trait ContextOps<C: Context> {
@@ -295,11 +300,6 @@ pub trait ResolventOps<C: Context, I: InferenceContext<C>> {
         answer_table_goal: &C::CanonicalGoalInEnvironment,
         canonical_answer_subst: &C::CanonicalConstrainedSubst,
     ) -> Fallible<ExClause<C, I>>;
-}
-
-pub trait Environment<C: Context, I: InferenceContext<C>>: Debug + Clone {
-    // Used by: simplify
-    fn add_clauses(&self, clauses: impl IntoIterator<Item = I::ProgramClause>) -> Self;
 }
 
 pub trait CanonicalExClause<C: Context>: Debug {

--- a/chalk-engine/src/context/mod.rs
+++ b/chalk-engine/src/context/mod.rs
@@ -53,7 +53,7 @@ pub trait ExClauseContext<C: Context>: Sized + Debug {
     type RegionConstraint: Debug;
 
     /// Represents a goal along with an environment.
-    type GoalInEnvironment: Debug + Clone + Eq + Ord + Hash;
+    type GoalInEnvironment: Debug + Clone + Eq + Hash;
 }
 
 /// The set of types belonging to an "inference context"; in rustc,

--- a/chalk-engine/src/context/prelude.rs
+++ b/chalk-engine/src/context/prelude.rs
@@ -4,7 +4,6 @@ crate use super::Context;
 crate use super::ContextOps;
 crate use super::ResolventOps;
 crate use super::TruncateOps;
-crate use super::Environment;
 crate use super::InferenceTable;
 crate use super::InferenceContext;
 crate use super::UCanonicalGoalInEnvironment;

--- a/chalk-engine/src/context/prelude.rs
+++ b/chalk-engine/src/context/prelude.rs
@@ -8,7 +8,6 @@ crate use super::Environment;
 crate use super::InferenceTable;
 crate use super::InferenceContext;
 crate use super::UnificationResult;
-crate use super::GoalInEnvironment;
 crate use super::UCanonicalGoalInEnvironment;
 crate use super::UniverseMap;
 crate use super::CanonicalExClause;

--- a/chalk-engine/src/context/prelude.rs
+++ b/chalk-engine/src/context/prelude.rs
@@ -12,4 +12,3 @@ crate use super::UCanonicalGoalInEnvironment;
 crate use super::UniverseMap;
 crate use super::CanonicalExClause;
 crate use super::CanonicalConstrainedSubst;
-crate use super::Goal;

--- a/chalk-engine/src/context/prelude.rs
+++ b/chalk-engine/src/context/prelude.rs
@@ -13,5 +13,3 @@ crate use super::UniverseMap;
 crate use super::CanonicalExClause;
 crate use super::CanonicalConstrainedSubst;
 crate use super::Goal;
-crate use super::DomainGoal;
-

--- a/chalk-engine/src/context/prelude.rs
+++ b/chalk-engine/src/context/prelude.rs
@@ -7,7 +7,6 @@ crate use super::TruncateOps;
 crate use super::Environment;
 crate use super::InferenceTable;
 crate use super::InferenceContext;
-crate use super::UnificationResult;
 crate use super::UCanonicalGoalInEnvironment;
 crate use super::UniverseMap;
 crate use super::CanonicalExClause;

--- a/chalk-engine/src/context/prelude.rs
+++ b/chalk-engine/src/context/prelude.rs
@@ -8,5 +8,4 @@ crate use super::InferenceTable;
 crate use super::InferenceContext;
 crate use super::UCanonicalGoalInEnvironment;
 crate use super::UniverseMap;
-crate use super::CanonicalExClause;
 crate use super::CanonicalConstrainedSubst;

--- a/chalk-engine/src/derived.rs
+++ b/chalk-engine/src/derived.rs
@@ -119,7 +119,7 @@ impl<C: Context> Hash for DelayedLiteral<C> {
 
 ///////////////////////////////////////////////////////////////////////////
 
-impl<C: Context, I: InferenceContext<C>> PartialEq for Literal<C, I> {
+impl<C: Context, I: ExClauseContext<C>> PartialEq for Literal<C, I> {
     fn eq(&self, other: &Literal<C, I>) -> bool {
         match (self, other) {
             (Literal::Positive(goal1), Literal::Positive(goal2))
@@ -130,10 +130,10 @@ impl<C: Context, I: InferenceContext<C>> PartialEq for Literal<C, I> {
     }
 }
 
-impl<C: Context, I: InferenceContext<C>> Eq for Literal<C, I> {
+impl<C: Context, I: ExClauseContext<C>> Eq for Literal<C, I> {
 }
 
-impl<C: Context, I: InferenceContext<C>> Hash for Literal<C, I> {
+impl<C: Context, I: ExClauseContext<C>> Hash for Literal<C, I> {
     fn hash<H: Hasher>(&self, state: &mut H) {
         mem::discriminant(self).hash(state);
         match self {

--- a/chalk-engine/src/lib.rs
+++ b/chalk-engine/src/lib.rs
@@ -60,7 +60,7 @@
 #[macro_use] extern crate chalk_macros;
 extern crate stacker;
 
-use crate::context::{Context, InferenceContext};
+use crate::context::{Context, ExClauseContext};
 use std::collections::HashSet;
 use std::cmp::min;
 use std::usize;
@@ -105,20 +105,20 @@ struct DepthFirstNumber {
 
 /// The paper describes these as `A :- D | G`.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
-pub struct ExClause<C: Context, I: InferenceContext<C>> {
+pub struct ExClause<C: Context, E: ExClauseContext<C>> {
     /// The substitution which, applied to the goal of our table,
     /// would yield A.
-    pub subst: I::Substitution,
+    pub subst: E::Substitution,
 
     /// Delayed literals: things that we depend on negatively,
     /// but which have not yet been fully evaluated.
     pub delayed_literals: Vec<DelayedLiteral<C>>,
 
     /// Region constraints we have accumulated.
-    pub constraints: Vec<I::RegionConstraint>,
+    pub constraints: Vec<E::RegionConstraint>,
 
     /// Subgoals: literals that must be proven
-    pub subgoals: Vec<Literal<C, I>>,
+    pub subgoals: Vec<Literal<C, E>>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
@@ -185,9 +185,9 @@ pub enum DelayedLiteral<C: Context> {
 
 /// Either `A` or `~A`, where `A` is a `Env |- Goal`.
 #[derive(Clone, Debug)]
-pub enum Literal<C: Context, I: InferenceContext<C>> { // FIXME: pub b/c fold
-    Positive(I::GoalInEnvironment),
-    Negative(I::GoalInEnvironment),
+pub enum Literal<C: Context, E: ExClauseContext<C>> { // FIXME: pub b/c fold
+    Positive(E::GoalInEnvironment),
+    Negative(E::GoalInEnvironment),
 }
 
 /// The `Minimums` structure is used to track the dependencies between

--- a/chalk-engine/src/lib.rs
+++ b/chalk-engine/src/lib.rs
@@ -55,7 +55,6 @@
 #![feature(in_band_lifetimes)]
 #![feature(macro_vis_matcher)]
 #![feature(step_trait)]
-#![feature(underscore_lifetimes)]
 
 #[macro_use] extern crate chalk_macros;
 extern crate stacker;

--- a/chalk-engine/src/logic.rs
+++ b/chalk-engine/src/logic.rs
@@ -115,7 +115,7 @@ impl<C: Context> Forest<C> {
         }
 
         self.tables[table].strands_mut().any(|strand| {
-            test(strand.canonical_ex_clause.inference_normalized_subst())
+            test(C::inference_normalized_subst(&strand.canonical_ex_clause))
         })
     }
 

--- a/chalk-engine/src/logic.rs
+++ b/chalk-engine/src/logic.rs
@@ -760,7 +760,7 @@ impl<C: Context> Forest<C> {
         goal: I::Goal,
     ) {
         let table_ref = &mut self.tables[table];
-        match goal.into_hh_goal() {
+        match I::into_hh_goal(goal) {
             HhGoal::DomainGoal(domain_goal) => {
                 let clauses = infer.program_clauses(&environment, &domain_goal);
                 for clause in clauses {

--- a/chalk-engine/src/simplify.rs
+++ b/chalk-engine/src/simplify.rs
@@ -45,7 +45,7 @@ impl<C: Context> Forest<C> {
                 HhGoal::Not(subgoal) => {
                     ex_clause
                         .subgoals
-                        .push(Literal::Negative(I::GoalInEnvironment::new(&environment, subgoal)));
+                        .push(Literal::Negative(I::goal_in_environment(&environment, subgoal)));
                 }
                 HhGoal::Unify(a, b) => {
                     infer.unify_parameters(&environment, &a, &b)?
@@ -54,7 +54,7 @@ impl<C: Context> Forest<C> {
                 HhGoal::DomainGoal(domain_goal) => {
                     ex_clause
                         .subgoals
-                        .push(Literal::Positive(I::GoalInEnvironment::new(
+                        .push(Literal::Positive(I::goal_in_environment(
                             &environment,
                             domain_goal.into_goal(),
                         )));
@@ -69,7 +69,7 @@ impl<C: Context> Forest<C> {
                     let goal = I::Goal::cannot_prove();
                     ex_clause
                         .subgoals
-                        .push(Literal::Negative(I::GoalInEnvironment::new(&environment, goal)));
+                        .push(Literal::Negative(I::goal_in_environment(&environment, goal)));
                 }
             }
         }

--- a/chalk-engine/src/simplify.rs
+++ b/chalk-engine/src/simplify.rs
@@ -48,8 +48,8 @@ impl<C: Context> Forest<C> {
                         .push(Literal::Negative(I::goal_in_environment(&environment, subgoal)));
                 }
                 HhGoal::Unify(a, b) => {
-                    infer.unify_parameters(&environment, &a, &b)?
-                        .into_ex_clause(&mut ex_clause)
+                    I::into_ex_clause(infer.unify_parameters(&environment, &a, &b)?,
+                                      &mut ex_clause)
                 }
                 HhGoal::DomainGoal(domain_goal) => {
                     ex_clause

--- a/chalk-engine/src/simplify.rs
+++ b/chalk-engine/src/simplify.rs
@@ -28,19 +28,19 @@ impl<C: Context> Forest<C> {
             match hh_goal {
                 HhGoal::ForAll(subgoal) => {
                     let subgoal = infer.instantiate_binders_universally(&subgoal);
-                    pending_goals.push((environment, subgoal.into_hh_goal()));
+                    pending_goals.push((environment, I::into_hh_goal(subgoal)));
                 }
                 HhGoal::Exists(subgoal) => {
                     let subgoal = infer.instantiate_binders_existentially(&subgoal);
-                    pending_goals.push((environment, subgoal.into_hh_goal()))
+                    pending_goals.push((environment, I::into_hh_goal(subgoal)))
                 }
                 HhGoal::Implies(wc, subgoal) => {
                     let new_environment = environment.add_clauses(wc);
-                    pending_goals.push((new_environment, subgoal.into_hh_goal()));
+                    pending_goals.push((new_environment, I::into_hh_goal(subgoal)));
                 }
                 HhGoal::And(subgoal1, subgoal2) => {
-                    pending_goals.push((environment.clone(), subgoal1.into_hh_goal()));
-                    pending_goals.push((environment, subgoal2.into_hh_goal()));
+                    pending_goals.push((environment.clone(), I::into_hh_goal(subgoal1)));
+                    pending_goals.push((environment, I::into_hh_goal(subgoal2)));
                 }
                 HhGoal::Not(subgoal) => {
                     ex_clause
@@ -66,7 +66,7 @@ impl<C: Context> Forest<C> {
                     // course, will always create a negative cycle and
                     // hence a delayed literal that cannot be
                     // resolved.
-                    let goal = I::Goal::cannot_prove();
+                    let goal = I::cannot_prove();
                     ex_clause
                         .subgoals
                         .push(Literal::Negative(I::goal_in_environment(&environment, goal)));

--- a/chalk-engine/src/simplify.rs
+++ b/chalk-engine/src/simplify.rs
@@ -56,7 +56,7 @@ impl<C: Context> Forest<C> {
                         .subgoals
                         .push(Literal::Positive(I::goal_in_environment(
                             &environment,
-                            domain_goal.into_goal(),
+                            I::into_goal(domain_goal),
                         )));
                 }
                 HhGoal::CannotProve => {

--- a/chalk-engine/src/simplify.rs
+++ b/chalk-engine/src/simplify.rs
@@ -35,7 +35,7 @@ impl<C: Context> Forest<C> {
                     pending_goals.push((environment, I::into_hh_goal(subgoal)))
                 }
                 HhGoal::Implies(wc, subgoal) => {
-                    let new_environment = environment.add_clauses(wc);
+                    let new_environment = I::add_clauses(&environment, wc);
                     pending_goals.push((new_environment, I::into_hh_goal(subgoal)));
                 }
                 HhGoal::And(subgoal1, subgoal2) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,6 @@
 #![feature(macro_vis_matcher)]
 #![feature(specialization)]
 #![feature(step_trait)]
-#![feature(underscore_lifetimes)]
 
 extern crate chalk_parse;
 #[macro_use]

--- a/src/solve/slg/implementation/mod.rs
+++ b/src/solve/slg/implementation/mod.rs
@@ -169,6 +169,13 @@ impl context::InferenceContext<SlgContext> for SlgContext {
             .extend(result.goals.into_iter().casted().map(Literal::Positive));
         ex_clause.constraints.extend(result.constraints);
     }
+
+    // Used by: simplify
+    fn add_clauses(env: &Self::Environment,
+                  clauses: impl IntoIterator<Item = Self::ProgramClause>)
+                  -> Self::Environment {
+        Environment::add_clauses(env, clauses)
+    }
 }
 
 impl context::UnificationOps<SlgContext, SlgContext> for TruncatingInferenceTable {
@@ -253,12 +260,6 @@ impl context::UnificationOps<SlgContext, SlgContext> for TruncatingInferenceTabl
         b: &Parameter,
     ) -> Fallible<UnificationResult> {
         self.infer.unify(environment, a, b)
-    }
-}
-
-impl context::Environment<SlgContext, SlgContext> for Arc<Environment> {
-    fn add_clauses(&self, clauses: impl IntoIterator<Item = ProgramClause>) -> Self {
-        Environment::add_clauses(self, clauses)
     }
 }
 

--- a/src/solve/slg/implementation/mod.rs
+++ b/src/solve/slg/implementation/mod.rs
@@ -144,6 +144,23 @@ impl context::InferenceContext<SlgContext> for SlgContext {
     fn into_goal(domain_goal: Self::DomainGoal) -> Self::Goal {
         domain_goal.cast()
     }
+
+    fn cannot_prove() -> Self::Goal {
+        Goal::CannotProve(())
+    }
+
+    fn into_hh_goal(goal: Self::Goal) -> HhGoal<SlgContext, Self> {
+        match goal {
+            Goal::Quantified(QuantifierKind::ForAll, binders_goal) => HhGoal::ForAll(binders_goal),
+            Goal::Quantified(QuantifierKind::Exists, binders_goal) => HhGoal::Exists(binders_goal),
+            Goal::Implies(dg, subgoal) => HhGoal::Implies(dg, *subgoal),
+            Goal::And(g1, g2) => HhGoal::And(*g1, *g2),
+            Goal::Not(g1) => HhGoal::Not(*g1),
+            Goal::Leaf(LeafGoal::EqGoal(EqGoal { a, b })) => HhGoal::Unify(a, b),
+            Goal::Leaf(LeafGoal::DomainGoal(domain_goal)) => HhGoal::DomainGoal(domain_goal),
+            Goal::CannotProve(()) => HhGoal::CannotProve,
+        }
+    }
 }
 
 impl context::UnificationOps<SlgContext, SlgContext> for TruncatingInferenceTable {
@@ -437,25 +454,6 @@ impl context::UCanonicalGoalInEnvironment<SlgContext> for UCanonical<InEnvironme
 
     fn is_trivial_substitution(&self, canonical_subst: &Canonical<ConstrainedSubst>) -> bool {
         self.is_trivial_substitution(canonical_subst)
-    }
-}
-
-impl context::Goal<SlgContext, SlgContext> for Goal {
-    fn cannot_prove() -> Goal {
-        Goal::CannotProve(())
-    }
-
-    fn into_hh_goal(self) -> HhGoal<SlgContext, SlgContext> {
-        match self {
-            Goal::Quantified(QuantifierKind::ForAll, binders_goal) => HhGoal::ForAll(binders_goal),
-            Goal::Quantified(QuantifierKind::Exists, binders_goal) => HhGoal::Exists(binders_goal),
-            Goal::Implies(dg, subgoal) => HhGoal::Implies(dg, *subgoal),
-            Goal::And(g1, g2) => HhGoal::And(*g1, *g2),
-            Goal::Not(g1) => HhGoal::Not(*g1),
-            Goal::Leaf(LeafGoal::EqGoal(EqGoal { a, b })) => HhGoal::Unify(a, b),
-            Goal::Leaf(LeafGoal::DomainGoal(domain_goal)) => HhGoal::DomainGoal(domain_goal),
-            Goal::CannotProve(()) => HhGoal::CannotProve,
-        }
     }
 }
 

--- a/src/solve/slg/implementation/mod.rs
+++ b/src/solve/slg/implementation/mod.rs
@@ -57,6 +57,11 @@ impl context::Context for SlgContext {
     type CanonicalConstrainedSubst = Canonical<ConstrainedSubst>;
     type InferenceNormalizedSubst = Substitution;
     type Solution = Solution;
+
+    fn inference_normalized_subst(canon_ex_clause: &Self::CanonicalExClause)
+                                  -> &Self::InferenceNormalizedSubst {
+        &canon_ex_clause.value.subst
+    }
 }
 
 impl context::ContextOps<SlgContext> for SlgContext {
@@ -422,12 +427,6 @@ impl context::UniverseMap<SlgContext> for ::crate::solve::infer::ucanonicalize::
         value: &Canonical<ConstrainedSubst>,
     ) -> Canonical<ConstrainedSubst> {
         self.map_from_canonical(value)
-    }
-}
-
-impl context::CanonicalExClause<SlgContext> for Canonical<ExClause<SlgContext, SlgContext>> {
-    fn inference_normalized_subst(&self) -> &Substitution {
-        &self.value.subst
     }
 }
 

--- a/src/solve/slg/implementation/mod.rs
+++ b/src/solve/slg/implementation/mod.rs
@@ -161,6 +161,14 @@ impl context::InferenceContext<SlgContext> for SlgContext {
             Goal::CannotProve(()) => HhGoal::CannotProve,
         }
     }
+
+    fn into_ex_clause(result: Self::UnificationResult,
+                      ex_clause: &mut ExClause<SlgContext, SlgContext>) {
+        ex_clause
+            .subgoals
+            .extend(result.goals.into_iter().casted().map(Literal::Positive));
+        ex_clause.constraints.extend(result.constraints);
+    }
 }
 
 impl context::UnificationOps<SlgContext, SlgContext> for TruncatingInferenceTable {
@@ -245,17 +253,6 @@ impl context::UnificationOps<SlgContext, SlgContext> for TruncatingInferenceTabl
         b: &Parameter,
     ) -> Fallible<UnificationResult> {
         self.infer.unify(environment, a, b)
-    }
-}
-
-impl context::UnificationResult<SlgContext, SlgContext>
-    for ::crate::solve::infer::unify::UnificationResult
-{
-    fn into_ex_clause(self, ex_clause: &mut ExClause<SlgContext, SlgContext>) {
-        ex_clause
-            .subgoals
-            .extend(self.goals.into_iter().casted().map(Literal::Positive));
-        ex_clause.constraints.extend(self.constraints);
     }
 }
 

--- a/src/solve/slg/implementation/mod.rs
+++ b/src/solve/slg/implementation/mod.rs
@@ -140,6 +140,10 @@ impl context::InferenceContext<SlgContext> for SlgContext {
     fn goal_in_environment(environment: &Arc<Environment>, goal: Goal) -> InEnvironment<Goal> {
         InEnvironment::new(environment, goal)
     }
+    
+    fn into_goal(domain_goal: Self::DomainGoal) -> Self::Goal {
+        domain_goal.cast()
+    }
 }
 
 impl context::UnificationOps<SlgContext, SlgContext> for TruncatingInferenceTable {
@@ -403,12 +407,6 @@ impl context::UniverseMap<SlgContext> for ::crate::solve::infer::ucanonicalize::
         value: &Canonical<ConstrainedSubst>,
     ) -> Canonical<ConstrainedSubst> {
         self.map_from_canonical(value)
-    }
-}
-
-impl context::DomainGoal<SlgContext, SlgContext> for DomainGoal {
-    fn into_goal(self) -> Goal {
-        self.cast()
     }
 }
 

--- a/src/solve/slg/implementation/mod.rs
+++ b/src/solve/slg/implementation/mod.rs
@@ -122,11 +122,14 @@ impl context::TruncateOps<SlgContext, SlgContext> for TruncatingInferenceTable {
 
 impl context::InferenceTable<SlgContext, SlgContext> for TruncatingInferenceTable {}
 
-impl context::InferenceContext<SlgContext> for SlgContext {
-    type Environment = Arc<Environment>;
+impl context::ExClauseContext<SlgContext> for SlgContext {
     type GoalInEnvironment = InEnvironment<Goal>;
     type Substitution = Substitution;
     type RegionConstraint = InEnvironment<Constraint>;
+}
+
+impl context::InferenceContext<SlgContext> for SlgContext {
+    type Environment = Arc<Environment>;
     type DomainGoal = DomainGoal;
     type Goal = Goal;
     type BindersGoal = Binders<Box<Goal>>;

--- a/src/solve/slg/implementation/resolvent.rs
+++ b/src/solve/slg/implementation/resolvent.rs
@@ -1,13 +1,13 @@
 use crate::fallible::Fallible;
-use crate::fold::Fold;
 use crate::fold::shift::Shift;
+use crate::fold::Fold;
 use crate::ir::*;
 use crate::solve::infer::InferenceTable;
 use crate::solve::slg::implementation::{SlgContext, TruncatingInferenceTable};
 use crate::zip::{Zip, Zipper};
 
-use chalk_engine::{ExClause, Literal};
 use chalk_engine::context::{self, InferenceContext};
+use chalk_engine::{ExClause, Literal};
 use std::sync::Arc;
 
 ///////////////////////////////////////////////////////////////////////////
@@ -209,7 +209,10 @@ impl context::ResolventOps<SlgContext, SlgContext> for TruncatingInferenceTable 
     ) -> Fallible<ExClause<SlgContext, SlgContext>> {
         debug_heading!("apply_answer_subst()");
         debug!("ex_clause={:?}", ex_clause);
-        debug!("selected_goal={:?}", self.infer.normalize_deep(selected_goal));
+        debug!(
+            "selected_goal={:?}",
+            self.infer.normalize_deep(selected_goal)
+        );
         debug!("answer_table_goal={:?}", answer_table_goal);
         debug!("canonical_answer_subst={:?}", canonical_answer_subst);
 
@@ -290,10 +293,11 @@ impl<'t> AnswerSubstitutor<'t> {
                 )
             });
 
-        SlgContext::into_ex_clause(self.table.unify(&self.environment,
-                                                    answer_param,
-                                                    pending_shifted)?,
-                                   &mut self.ex_clause);
+        SlgContext::into_ex_clause(
+            self.table
+                .unify(&self.environment, answer_param, pending_shifted)?,
+            &mut self.ex_clause,
+        );
 
         Ok(true)
     }

--- a/src/solve/slg/implementation/resolvent.rs
+++ b/src/solve/slg/implementation/resolvent.rs
@@ -7,7 +7,7 @@ use crate::solve::slg::implementation::{SlgContext, TruncatingInferenceTable};
 use crate::zip::{Zip, Zipper};
 
 use chalk_engine::{ExClause, Literal};
-use chalk_engine::context::{self, UnificationResult as UnificationResultTrait};
+use chalk_engine::context::{self, InferenceContext};
 use std::sync::Arc;
 
 ///////////////////////////////////////////////////////////////////////////
@@ -105,7 +105,7 @@ impl context::ResolventOps<SlgContext, SlgContext> for TruncatingInferenceTable 
         };
 
         // Add the subgoals/region-constraints that unification gave us.
-        unification_result.into_ex_clause(&mut ex_clause);
+        SlgContext::into_ex_clause(unification_result, &mut ex_clause);
 
         // Add the `conditions` from the program clause into the result too.
         ex_clause
@@ -290,9 +290,10 @@ impl<'t> AnswerSubstitutor<'t> {
                 )
             });
 
-        self.table
-            .unify(&self.environment, answer_param, pending_shifted)?
-            .into_ex_clause(&mut self.ex_clause);
+        SlgContext::into_ex_clause(self.table.unify(&self.environment,
+                                                    answer_param,
+                                                    pending_shifted)?,
+                                   &mut self.ex_clause);
 
         Ok(true)
     }


### PR DESCRIPTION
Remove `GoalInEnvironment`, `DomainGoal`, `Goal`, `UnificationResult`, `CanonicalExClause` and `Environment` traits in favor of associated functions. They where causing coherence issues in rustc. Also they are arguably not worth it anyways since they only bring us method syntax.