### PR TITLE
rust-toolchain file so we always build on nightly by default

### DIFF
--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,0 +1,1 @@
+nightly


### PR DESCRIPTION
This is a more convenient way that people can always build the project just by running `cargo build`. No need to setup overrides or anything else. Cargo and rustup will figure everything out for you!