### PR TITLE
dyn_trait has been stable since Rust 1.27

### DIFF
--- a/chalk-engine/src/lib.rs
+++ b/chalk-engine/src/lib.rs
@@ -51,7 +51,6 @@
 
 #![feature(crate_in_paths)]
 #![feature(crate_visibility_modifier)]
-#![feature(dyn_trait)]
 #![feature(in_band_lifetimes)]
 #![feature(macro_vis_matcher)]
 #![feature(step_trait)]


### PR DESCRIPTION
This is stable now and we should remove the feature gate.