### PR TITLE
Revert "dyn_trait has been stable since Rust 1.27"

### DIFF
--- a/chalk-engine/src/lib.rs
+++ b/chalk-engine/src/lib.rs
@@ -51,6 +51,7 @@
 
 #![feature(crate_in_paths)]
 #![feature(crate_visibility_modifier)]
+#![feature(dyn_trait)]
 #![feature(in_band_lifetimes)]
 #![feature(macro_vis_matcher)]
 #![feature(step_trait)]


### PR DESCRIPTION
Reverts rust-lang-nursery/chalk#125

@nikomatsakis 