### PR TITLE
Fix bug in overlaps where it was not handling the ambig case

### DIFF
--- a/src/coherence/solve.rs
+++ b/src/coherence/solve.rs
@@ -7,7 +7,7 @@ use ir::*;
 use cast::*;
 use solve::SolverChoice;
 
-struct OverlapSolver {
+struct DisjointSolver {
     env: Arc<ProgramEnvironment>,
     solver_choice: SolverChoice,
 }
@@ -21,7 +21,7 @@ impl Program {
     where
         F: FnMut(ItemId, ItemId),
     {
-        let mut solver = OverlapSolver {
+        let mut solver = DisjointSolver {
             env: Arc::new(self.environment()),
             solver_choice,
         };
@@ -65,7 +65,7 @@ impl Program {
                 // Check if the impls overlap, then if they do, check if one specializes
                 // the other. Note that specialization can only run one way - if both
                 // specialization checks return *either* true or false, that's an error.
-                if solver.overlaps(lhs, rhs) {
+                if !solver.disjoint(lhs, rhs) {
                     match (solver.specializes(lhs, rhs), solver.specializes(rhs, lhs)) {
                         (true, false) => record_specialization(l_id, r_id),
                         (false, true) => record_specialization(r_id, l_id),
@@ -82,15 +82,14 @@ impl Program {
     }
 }
 
-impl OverlapSolver {
-    // Test for overlap.
-    //
-    // If this test succeeds, these two impls overlap.
+impl DisjointSolver {
+    // Test if two impls are disjoint. If the test does not succeed, there is an overlap.
     //
     // We combine the binders of the two impls & treat them as existential
     // quantifiers. Then we attempt to unify the input types to the trait provided
     // by each impl, as well as prove that the where clauses from both impls all
-    // hold.
+    // hold. At the end, we negate the query because we only want to return `true` if
+    // it is provable that there is no overlap.
     //
     // Examples:
     //
@@ -98,22 +97,21 @@ impl OverlapSolver {
     //      impl<T> Foo for T { }
     //      impl Foo for i32 { }
     //  Generates:
-    //      exists<T> { T = i32 }
+    //      not { exists<T> { T = i32 } }
     //
     //  Impls:
     //      impl<T1, U> Foo<T1> for Vec<U> { }
     //      impl<T2> Foo<T2> for Vec<i32> { }
     //  Generates:
-    //      exists<T1, U, T2> { Vec<U> = Vec<i32>, T1 = T2 }
-    //
+    //      not { exists<T1, U, T2> { Vec<U> = Vec<i32>, T1 = T2 } }
     //
     //  Impls:
     //      impl<T> Foo for Vec<T> where T: Bar { }
     //      impl<U> Foo for Vec<U> where U: Baz { }
     //  Generates:
-    //      exists<T, U> { Vec<T> = Vec<U>, T: Bar, U: Baz }
+    //      not { exists<T, U> { Vec<T> = Vec<U>, T: Bar, U: Baz } }
     //
-    fn overlaps(&self, lhs: &ImplDatum, rhs: &ImplDatum) -> bool {
+    fn disjoint(&self, lhs: &ImplDatum, rhs: &ImplDatum) -> bool {
         debug_heading!("overlaps(lhs={:#?}, rhs={:#?})", lhs, rhs);
 
         let lhs_len = lhs.binders.len();
@@ -151,7 +149,8 @@ impl OverlapSolver {
             .chain(wc_goals)
             .fold1(|goal, leaf| Goal::And(Box::new(goal), Box::new(leaf)))
             .expect("Every trait takes at least one input type")
-            .quantify(QuantifierKind::Exists, binders);
+            .quantify(QuantifierKind::Exists, binders)
+            .negate();
 
         // Unless we can prove NO solution, we consider things to overlap.
         let canonical_goal = &goal.into_closed_goal();

--- a/src/ir.rs
+++ b/src/ir.rs
@@ -854,6 +854,10 @@ impl Goal {
         )
     }
 
+    crate fn negate(self) -> Self {
+        Goal::Not(Box::new(self))
+    }
+
     crate fn implied_by(self, predicates: Vec<ProgramClause>) -> Goal {
         Goal::Implies(predicates, Box::new(self))
     }


### PR DESCRIPTION
This is the first of many pull requests towards implementing #92.

While explaining what to do for that issue, @nikomatsakis realized that the `overlaps` method actually had a bug in it. With the way the code is written, when you solve a root goal, you either get Yes or No/Maybe. If you really want a No answer, you are meant to use a `not { ... }` goal. The `overlaps` method was relying on the No/Maybe answer, but really we would like to use `not` and look for a Yes result.

This PR converts the `overlaps` method into a method called `disjoint`. The majority of the code is the same, but now we negate the entire query by wrapping it in a `not { ... }` goal. The `disjoint` method returns `true` if we can prove with certainty that there is NO overlap.

This is my first PR with actual code changes, so I am very open to your feedback on both my code and my explanation of the changes above. :smile: 