### PR TITLE
One big happy family

### DIFF
--- a/chalk-engine/src/context.rs
+++ b/chalk-engine/src/context.rs
@@ -12,7 +12,7 @@ crate mod prelude;
 ///
 /// At any given time, the SLG solver may have more than one context
 /// active. First, there is always the *global* context, but when we
-/// are in the midst of pursuing some particular strange, we will
+/// are in the midst of pursuing some particular strand, we will
 /// instantiate a second context just for that work, via the
 /// `instantiate_ucanonical_goal` and `instantiate_ex_clause` methods.
 ///

--- a/chalk-engine/src/context.rs
+++ b/chalk-engine/src/context.rs
@@ -100,6 +100,9 @@ pub trait Context: Clone + Debug {
     /// goal we are trying to solve to produce an ex-clause.
     type ProgramClause: Debug;
 
+    /// A vector of program clauses.
+    type ProgramClauses: Debug;
+
     /// The successful result from unification: contains new subgoals
     /// and things that can be attached to an ex-clause.
     type UnificationResult;
@@ -245,7 +248,7 @@ pub trait InferenceTable<C: Context, I: Context>:
     fn add_clauses(
         &mut self,
         env: &I::Environment,
-        clauses: Vec<I::ProgramClause>,
+        clauses: I::ProgramClauses,
     ) -> I::Environment;
 }
 

--- a/chalk-engine/src/context.rs
+++ b/chalk-engine/src/context.rs
@@ -104,7 +104,8 @@ pub trait Context: Clone + Debug {
     /// and things that can be attached to an ex-clause.
     type UnificationResult;
 
-    /// Given an environment and a goal, glue them together to create a `GoalInEnvironment`.
+    /// Given an environment and a goal, glue them together to create
+    /// a `GoalInEnvironment`.
     fn goal_in_environment(
         environment: &Self::Environment,
         goal: Self::Goal,
@@ -115,22 +116,6 @@ pub trait Context: Clone + Debug {
 
     /// Create a "cannot prove" goal (see `HhGoal::CannotProve`).
     fn cannot_prove() -> Self::Goal;
-
-    /// Convert the context's goal type into the `HhGoal` type that
-    /// the SLG solver understands. The expectation is that the
-    /// context's goal type has the same set of variants, but with
-    /// different names and a different setup. If you inspect
-    /// `HhGoal`, you will see that this is a "shallow" or "lazy"
-    /// conversion -- that is, we convert the outermost goal into an
-    /// `HhGoal`, but the goals contained within are left as context
-    /// goals.
-    fn into_hh_goal(goal: Self::Goal) -> HhGoal<Self>;
-
-    // Used by: simplify
-    fn add_clauses(
-        env: &Self::Environment,
-        clauses: impl IntoIterator<Item = Self::ProgramClause>,
-    ) -> Self::Environment;
 }
 
 pub trait ContextOps<C: Context>: Sized + Clone + Debug + AggregateOps<C> {
@@ -246,6 +231,22 @@ pub trait AggregateOps<C: Context> {
 pub trait InferenceTable<C: Context, I: Context>:
     ResolventOps<C, I> + TruncateOps<C, I> + UnificationOps<C, I>
 {
+    /// Convert the context's goal type into the `HhGoal` type that
+    /// the SLG solver understands. The expectation is that the
+    /// context's goal type has the same set of variants, but with
+    /// different names and a different setup. If you inspect
+    /// `HhGoal`, you will see that this is a "shallow" or "lazy"
+    /// conversion -- that is, we convert the outermost goal into an
+    /// `HhGoal`, but the goals contained within are left as context
+    /// goals.
+    fn into_hh_goal(&mut self, goal: I::Goal) -> HhGoal<I>;
+
+    // Used by: simplify
+    fn add_clauses(
+        &mut self,
+        env: &I::Environment,
+        clauses: Vec<I::ProgramClause>,
+    ) -> I::Environment;
 }
 
 /// Methods for unifying and manipulating terms and binders.

--- a/chalk-engine/src/context/prelude.rs
+++ b/chalk-engine/src/context/prelude.rs
@@ -6,4 +6,3 @@ crate use super::AggregateOps;
 crate use super::ResolventOps;
 crate use super::TruncateOps;
 crate use super::InferenceTable;
-crate use super::InferenceContext;

--- a/chalk-engine/src/context/prelude.rs
+++ b/chalk-engine/src/context/prelude.rs
@@ -1,5 +1,6 @@
 #![allow(unused_imports)] // rustc bug
 
+crate use super::ExClauseContext;
 crate use super::Context;
 crate use super::ContextOps;
 crate use super::AggregateOps;

--- a/chalk-engine/src/context/prelude.rs
+++ b/chalk-engine/src/context/prelude.rs
@@ -1,6 +1,5 @@
 #![allow(unused_imports)] // rustc bug
 
-crate use super::ExClauseContext;
 crate use super::Context;
 crate use super::ContextOps;
 crate use super::AggregateOps;

--- a/chalk-engine/src/derived.rs
+++ b/chalk-engine/src/derived.rs
@@ -7,7 +7,7 @@ use std::hash::{Hash, Hasher};
 use std::mem;
 use super::*;
 
-impl<E: ExClauseContext> PartialEq for DelayedLiteralSet<E> {
+impl<C: Context> PartialEq for DelayedLiteralSet<C> {
     fn eq(&self, other: &Self) -> bool {
         let DelayedLiteralSet { delayed_literals: a1 } = self;
         let DelayedLiteralSet { delayed_literals: a2 } = other;
@@ -15,12 +15,12 @@ impl<E: ExClauseContext> PartialEq for DelayedLiteralSet<E> {
     }
 }
 
-impl<E: ExClauseContext> Eq for DelayedLiteralSet<E> {
+impl<C: Context> Eq for DelayedLiteralSet<C> {
 }
 
 ///////////////////////////////////////////////////////////////////////////
 
-impl<E: ExClauseContext> PartialEq for DelayedLiteral<E> {
+impl<C: Context> PartialEq for DelayedLiteral<C> {
     fn eq(&self, other: &Self) -> bool {
         if mem::discriminant(self) != mem::discriminant(other) {
             return false;
@@ -41,10 +41,10 @@ impl<E: ExClauseContext> PartialEq for DelayedLiteral<E> {
     }
 }
 
-impl<E: ExClauseContext> Eq for DelayedLiteral<E> {
+impl<C: Context> Eq for DelayedLiteral<C> {
 }
 
-impl<E: ExClauseContext> Hash for DelayedLiteral<E> {
+impl<C: Context> Hash for DelayedLiteral<C> {
     fn hash<H: Hasher>(&self, hasher: &mut H) {
         mem::discriminant(self).hash(hasher);
 
@@ -65,8 +65,8 @@ impl<E: ExClauseContext> Hash for DelayedLiteral<E> {
 
 ///////////////////////////////////////////////////////////////////////////
 
-impl<I: ExClauseContext> PartialEq for Literal<I> {
-    fn eq(&self, other: &Literal<I>) -> bool {
+impl<C: Context> PartialEq for Literal<C> {
+    fn eq(&self, other: &Literal<C>) -> bool {
         match (self, other) {
             (Literal::Positive(goal1), Literal::Positive(goal2))
             | (Literal::Negative(goal1), Literal::Negative(goal2)) => goal1 == goal2,
@@ -76,10 +76,10 @@ impl<I: ExClauseContext> PartialEq for Literal<I> {
     }
 }
 
-impl<I: ExClauseContext> Eq for Literal<I> {
+impl<C: Context> Eq for Literal<C> {
 }
 
-impl<I: ExClauseContext> Hash for Literal<I> {
+impl<C: Context> Hash for Literal<C> {
     fn hash<H: Hasher>(&self, state: &mut H) {
         mem::discriminant(self).hash(state);
         match self {

--- a/chalk-engine/src/derived.rs
+++ b/chalk-engine/src/derived.rs
@@ -7,7 +7,7 @@ use std::hash::{Hash, Hasher};
 use std::mem;
 use super::*;
 
-impl<C: Context> PartialEq for DelayedLiteralSet<C> {
+impl<E: ExClauseContext> PartialEq for DelayedLiteralSet<E> {
     fn eq(&self, other: &Self) -> bool {
         let DelayedLiteralSet { delayed_literals: a1 } = self;
         let DelayedLiteralSet { delayed_literals: a2 } = other;
@@ -15,12 +15,12 @@ impl<C: Context> PartialEq for DelayedLiteralSet<C> {
     }
 }
 
-impl<C: Context> Eq for DelayedLiteralSet<C> {
+impl<E: ExClauseContext> Eq for DelayedLiteralSet<E> {
 }
 
 ///////////////////////////////////////////////////////////////////////////
 
-impl<C: Context> PartialEq for DelayedLiteral<C> {
+impl<E: ExClauseContext> PartialEq for DelayedLiteral<E> {
     fn eq(&self, other: &Self) -> bool {
         if mem::discriminant(self) != mem::discriminant(other) {
             return false;
@@ -41,10 +41,10 @@ impl<C: Context> PartialEq for DelayedLiteral<C> {
     }
 }
 
-impl<C: Context> Eq for DelayedLiteral<C> {
+impl<E: ExClauseContext> Eq for DelayedLiteral<E> {
 }
 
-impl<C: Context> Hash for DelayedLiteral<C> {
+impl<E: ExClauseContext> Hash for DelayedLiteral<E> {
     fn hash<H: Hasher>(&self, hasher: &mut H) {
         mem::discriminant(self).hash(hasher);
 
@@ -65,8 +65,8 @@ impl<C: Context> Hash for DelayedLiteral<C> {
 
 ///////////////////////////////////////////////////////////////////////////
 
-impl<C: Context, I: ExClauseContext<C>> PartialEq for Literal<C, I> {
-    fn eq(&self, other: &Literal<C, I>) -> bool {
+impl<I: ExClauseContext> PartialEq for Literal<I> {
+    fn eq(&self, other: &Literal<I>) -> bool {
         match (self, other) {
             (Literal::Positive(goal1), Literal::Positive(goal2))
             | (Literal::Negative(goal1), Literal::Negative(goal2)) => goal1 == goal2,
@@ -76,10 +76,10 @@ impl<C: Context, I: ExClauseContext<C>> PartialEq for Literal<C, I> {
     }
 }
 
-impl<C: Context, I: ExClauseContext<C>> Eq for Literal<C, I> {
+impl<I: ExClauseContext> Eq for Literal<I> {
 }
 
-impl<C: Context, I: ExClauseContext<C>> Hash for Literal<C, I> {
+impl<I: ExClauseContext> Hash for Literal<I> {
     fn hash<H: Hasher>(&self, state: &mut H) {
         mem::discriminant(self).hash(state);
         match self {

--- a/chalk-engine/src/hh.rs
+++ b/chalk-engine/src/hh.rs
@@ -1,17 +1,17 @@
-use crate::context::{Context, InferenceContext};
+use crate::context::Context;
 
 #[derive(Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 /// A general goal; this is the full range of questions you can pose to Chalk.
-pub enum HhGoal<C: Context, I: InferenceContext<C>> {
+pub enum HhGoal<C: Context> {
     /// Introduces a binding at depth 0, shifting other bindings up
     /// (deBruijn index).
-    ForAll(I::BindersGoal),
-    Exists(I::BindersGoal),
-    Implies(Vec<I::ProgramClause>, I::Goal),
-    And(I::Goal, I::Goal),
-    Not(I::Goal),
-    Unify(I::Parameter, I::Parameter),
-    DomainGoal(I::DomainGoal),
+    ForAll(C::BindersGoal),
+    Exists(C::BindersGoal),
+    Implies(Vec<C::ProgramClause>, C::Goal),
+    And(C::Goal, C::Goal),
+    Not(C::Goal),
+    Unify(C::Parameter, C::Parameter),
+    DomainGoal(C::DomainGoal),
 
     /// Indicates something that cannot be proven to be true or false
     /// definitively. This can occur with overflow but also with

--- a/chalk-engine/src/hh.rs
+++ b/chalk-engine/src/hh.rs
@@ -7,7 +7,7 @@ pub enum HhGoal<C: Context> {
     /// (deBruijn index).
     ForAll(C::BindersGoal),
     Exists(C::BindersGoal),
-    Implies(Vec<C::ProgramClause>, C::Goal),
+    Implies(C::ProgramClauses, C::Goal),
     And(C::Goal, C::Goal),
     Not(C::Goal),
     Unify(C::Parameter, C::Parameter),

--- a/chalk-engine/src/logic.rs
+++ b/chalk-engine/src/logic.rs
@@ -293,7 +293,7 @@ impl<C: Context, CO: ContextOps<C>> Forest<C, CO> {
             WithInstantiatedExClause<C> for With<C, CO, OP> {
             type Output = OP::Output;
 
-            fn with<I: InferenceContext<C>>(
+            fn with<I: Context>(
                 self,
                 infer: &mut dyn InferenceTable<C, I>,
                 ex_clause: ExClause<I>,
@@ -307,7 +307,7 @@ impl<C: Context, CO: ContextOps<C>> Forest<C, CO> {
         }
     }
 
-    fn canonicalize_strand(strand: Strand<'_, C, impl InferenceContext<C>>) -> CanonicalStrand<C> {
+    fn canonicalize_strand(strand: Strand<'_, C, impl Context>) -> CanonicalStrand<C> {
         let Strand {
             infer,
             ex_clause,
@@ -316,7 +316,7 @@ impl<C: Context, CO: ContextOps<C>> Forest<C, CO> {
         Self::canonicalize_strand_from(&mut *infer, &ex_clause, selected_subgoal)
     }
 
-    fn canonicalize_strand_from<I: InferenceContext<C>>(
+    fn canonicalize_strand_from<I: Context>(
         infer: &mut dyn InferenceTable<C, I>,
         ex_clause: &ExClause<I>,
         selected_subgoal: Option<SelectedSubgoal<C>>,
@@ -431,7 +431,7 @@ impl<C: Context, CO: ContextOps<C>> Forest<C, CO> {
 
     fn delay_strand_after_cycle(
         table: TableIndex,
-        mut strand: Strand<'_, C, impl InferenceContext<C>>,
+        mut strand: Strand<'_, C, impl Context>,
     ) -> (CanonicalStrand<C>, TableIndex) {
         let (subgoal_index, subgoal_table) = match &strand.selected_subgoal {
             Some(selected_subgoal) => (
@@ -467,7 +467,7 @@ impl<C: Context, CO: ContextOps<C>> Forest<C, CO> {
     fn pursue_strand(
         &mut self,
         depth: StackIndex,
-        mut strand: Strand<'_, C, impl InferenceContext<C>>,
+        mut strand: Strand<'_, C, impl Context>,
     ) -> StrandResult<C, ()> {
         info_heading!(
             "pursue_strand(table={:?}, depth={:?}, ex_clause={:#?}, selected_subgoal={:?})",
@@ -541,7 +541,7 @@ impl<C: Context, CO: ContextOps<C>> Forest<C, CO> {
     fn pursue_answer(
         &mut self,
         depth: StackIndex,
-        strand: Strand<'_, C, impl InferenceContext<C>>,
+        strand: Strand<'_, C, impl Context>,
     ) -> StrandResult<C, ()> {
         let table = self.stack[depth].table;
         let Strand {
@@ -662,7 +662,7 @@ impl<C: Context, CO: ContextOps<C>> Forest<C, CO> {
     /// In terms of the NFTD paper, creating a new table corresponds
     /// to the *New Subgoal* step as well as the *Program Clause
     /// Resolution* steps.
-    fn get_or_create_table_for_subgoal<I: InferenceContext<C>>(
+    fn get_or_create_table_for_subgoal<I: Context>(
         &mut self,
         infer: &mut dyn InferenceTable<C, I>,
         subgoal: &Literal<I>,
@@ -741,7 +741,7 @@ impl<C: Context, CO: ContextOps<C>> Forest<C, CO> {
                                                 for PushInitialStrandsInstantiated<'a, C, CO> {
             type Output = ();
 
-            fn with<I: InferenceContext<C>>(
+            fn with<I: Context>(
                 self,
                 infer: &mut dyn InferenceTable<C, I>,
                 subst: I::Substitution,
@@ -754,7 +754,7 @@ impl<C: Context, CO: ContextOps<C>> Forest<C, CO> {
         }
     }
 
-    fn push_initial_strands_instantiated<I: InferenceContext<C>>(
+    fn push_initial_strands_instantiated<I: Context>(
         &mut self,
         table: TableIndex,
         infer: &mut dyn InferenceTable<C, I>,
@@ -814,7 +814,7 @@ impl<C: Context, CO: ContextOps<C>> Forest<C, CO> {
     /// truncate the goal to ensure termination.
     ///
     /// This technique is described in the SA paper.
-    fn abstract_positive_literal<I: InferenceContext<C>>(
+    fn abstract_positive_literal<I: Context>(
         &mut self,
         infer: &mut dyn InferenceTable<C, I>,
         subgoal: &I::GoalInEnvironment,
@@ -858,7 +858,7 @@ impl<C: Context, CO: ContextOps<C>> Forest<C, CO> {
     /// fail to yield a useful result, for example if free existential
     /// variables appear in `subgoal` (in which case the execution is
     /// said to "flounder").
-    fn abstract_negative_literal<I: InferenceContext<C>>(
+    fn abstract_negative_literal<I: Context>(
         &mut self,
         infer: &mut dyn InferenceTable<C, I>,
         subgoal: &I::GoalInEnvironment,
@@ -973,7 +973,7 @@ impl<C: Context, CO: ContextOps<C>> Forest<C, CO> {
     fn pursue_positive_subgoal(
         &mut self,
         depth: StackIndex,
-        mut strand: Strand<'_, C, impl InferenceContext<C>>,
+        mut strand: Strand<'_, C, impl Context>,
         selected_subgoal: &SelectedSubgoal<C>,
     ) -> StrandResult<C, ()> {
         let table = self.stack[depth].table;
@@ -1097,7 +1097,7 @@ impl<C: Context, CO: ContextOps<C>> Forest<C, CO> {
     /// Used whenever we process an answer (whether new or cached) on
     /// a positive edge (the SLG POSITIVE RETURN operation). Truncates
     /// the resolvent (or factor) if it has grown too large.
-    fn truncate_returned<I: InferenceContext<C>>(
+    fn truncate_returned<I: Context>(
         &self,
         ex_clause: ExClause<I>,
         infer: &mut dyn InferenceTable<C, I>,
@@ -1164,7 +1164,7 @@ impl<C: Context, CO: ContextOps<C>> Forest<C, CO> {
     fn pursue_strand_recursively(
         &mut self,
         depth: StackIndex,
-        strand: Strand<'_, C, impl InferenceContext<C>>,
+        strand: Strand<'_, C, impl Context>,
     ) -> StrandResult<C, ()> {
         ::crate::maybe_grow_stack(|| self.pursue_strand(depth, strand))
     }
@@ -1175,7 +1175,7 @@ impl<C: Context, CO: ContextOps<C>> Forest<C, CO> {
     fn push_strand_pursuing_next_answer(
         &mut self,
         depth: StackIndex,
-        strand: &mut Strand<'_, C, impl InferenceContext<C>>,
+        strand: &mut Strand<'_, C, impl Context>,
         selected_subgoal: &SelectedSubgoal<C>,
     ) {
         let table = self.stack[depth].table;
@@ -1191,7 +1191,7 @@ impl<C: Context, CO: ContextOps<C>> Forest<C, CO> {
     fn pursue_negative_subgoal(
         &mut self,
         depth: StackIndex,
-        strand: Strand<'_, C, impl InferenceContext<C>>,
+        strand: Strand<'_, C, impl Context>,
         selected_subgoal: &SelectedSubgoal<C>,
     ) -> StrandResult<C, ()> {
         let table = self.stack[depth].table;
@@ -1311,7 +1311,7 @@ impl<C: Context, CO: ContextOps<C>> Forest<C, CO> {
 trait WithInstantiatedStrand<C: Context, CO: AggregateOps<C>> {
     type Output;
 
-    fn with(self, strand: Strand<'_, C, impl InferenceContext<C>>) -> Self::Output;
+    fn with(self, strand: Strand<'_, C, impl Context>) -> Self::Output;
 }
 
 struct PursueStrand<'a, C: Context + 'a, CO: ContextOps<C> + 'a> {
@@ -1322,7 +1322,7 @@ struct PursueStrand<'a, C: Context + 'a, CO: ContextOps<C> + 'a> {
 impl<C: Context, CO: ContextOps<C>> WithInstantiatedStrand<C, CO> for PursueStrand<'a, C, CO> {
     type Output = StrandResult<C, ()>;
 
-    fn with(self, strand: Strand<'_, C, impl InferenceContext<C>>) -> Self::Output {
+    fn with(self, strand: Strand<'_, C, impl Context>) -> Self::Output {
         self.forest.pursue_strand(self.depth, strand)
     }
 }
@@ -1334,7 +1334,7 @@ struct DelayStrandAfterCycle {
 impl<C: Context, CO: ContextOps<C>> WithInstantiatedStrand<C, CO> for DelayStrandAfterCycle {
     type Output = (CanonicalStrand<C>, TableIndex);
 
-    fn with(self, strand: Strand<'_, C, impl InferenceContext<C>>) -> Self::Output {
+    fn with(self, strand: Strand<'_, C, impl Context>) -> Self::Output {
         <Forest<C, CO>>::delay_strand_after_cycle(self.table, strand)
     }
 }

--- a/chalk-engine/src/logic.rs
+++ b/chalk-engine/src/logic.rs
@@ -763,7 +763,7 @@ impl<C: Context, CO: ContextOps<C>> Forest<C, CO> {
         goal: I::Goal,
     ) {
         let table_ref = &mut self.tables[table];
-        match I::into_hh_goal(goal) {
+        match infer.into_hh_goal(goal) {
             HhGoal::DomainGoal(domain_goal) => {
                 let clauses = infer.program_clauses(&environment, &domain_goal);
                 for clause in clauses {

--- a/chalk-engine/src/simplify.rs
+++ b/chalk-engine/src/simplify.rs
@@ -28,19 +28,19 @@ impl<C: Context, CO: ContextOps<C>> Forest<C, CO> {
             match hh_goal {
                 HhGoal::ForAll(subgoal) => {
                     let subgoal = infer.instantiate_binders_universally(&subgoal);
-                    pending_goals.push((environment, I::into_hh_goal(subgoal)));
+                    pending_goals.push((environment, infer.into_hh_goal(subgoal)));
                 }
                 HhGoal::Exists(subgoal) => {
                     let subgoal = infer.instantiate_binders_existentially(&subgoal);
-                    pending_goals.push((environment, I::into_hh_goal(subgoal)))
+                    pending_goals.push((environment, infer.into_hh_goal(subgoal)))
                 }
                 HhGoal::Implies(wc, subgoal) => {
-                    let new_environment = I::add_clauses(&environment, wc);
-                    pending_goals.push((new_environment, I::into_hh_goal(subgoal)));
+                    let new_environment = infer.add_clauses(&environment, wc);
+                    pending_goals.push((new_environment, infer.into_hh_goal(subgoal)));
                 }
                 HhGoal::And(subgoal1, subgoal2) => {
-                    pending_goals.push((environment.clone(), I::into_hh_goal(subgoal1)));
-                    pending_goals.push((environment, I::into_hh_goal(subgoal2)));
+                    pending_goals.push((environment.clone(), infer.into_hh_goal(subgoal1)));
+                    pending_goals.push((environment, infer.into_hh_goal(subgoal2)));
                 }
                 HhGoal::Not(subgoal) => {
                     ex_clause

--- a/chalk-engine/src/simplify.rs
+++ b/chalk-engine/src/simplify.rs
@@ -8,7 +8,7 @@ impl<C: Context, CO: ContextOps<C>> Forest<C, CO> {
     /// Simplifies an HH goal into a series of positive domain goals
     /// and negative HH goals. This operation may fail if the HH goal
     /// includes unifications that cannot be completed.
-    pub(super) fn simplify_hh_goal<I: InferenceContext<C>>(
+    pub(super) fn simplify_hh_goal<I: Context>(
         infer: &mut dyn InferenceTable<C, I>,
         subst: I::Substitution,
         initial_environment: &I::Environment,
@@ -48,8 +48,8 @@ impl<C: Context, CO: ContextOps<C>> Forest<C, CO> {
                         .push(Literal::Negative(I::goal_in_environment(&environment, subgoal)));
                 }
                 HhGoal::Unify(a, b) => {
-                    I::into_ex_clause(infer.unify_parameters(&environment, &a, &b)?,
-                                      &mut ex_clause)
+                    let result = infer.unify_parameters(&environment, &a, &b)?;
+                    infer.into_ex_clause(result, &mut ex_clause)
                 }
                 HhGoal::DomainGoal(domain_goal) => {
                     ex_clause

--- a/chalk-engine/src/simplify.rs
+++ b/chalk-engine/src/simplify.rs
@@ -13,7 +13,7 @@ impl<C: Context, CO: ContextOps<C>> Forest<C, CO> {
         subst: I::Substitution,
         initial_environment: &I::Environment,
         initial_hh_goal: HhGoal<C, I>,
-    ) -> Fallible<ExClause<C, I>> {
+    ) -> Fallible<ExClause<I>> {
         let mut ex_clause = ExClause {
             subst,
             delayed_literals: vec![],

--- a/chalk-engine/src/simplify.rs
+++ b/chalk-engine/src/simplify.rs
@@ -12,7 +12,7 @@ impl<C: Context, CO: ContextOps<C>> Forest<C, CO> {
         infer: &mut dyn InferenceTable<C, I>,
         subst: I::Substitution,
         initial_environment: &I::Environment,
-        initial_hh_goal: HhGoal<C, I>,
+        initial_hh_goal: HhGoal<I>,
     ) -> Fallible<ExClause<I>> {
         let mut ex_clause = ExClause {
             subst,

--- a/chalk-engine/src/strand.rs
+++ b/chalk-engine/src/strand.rs
@@ -14,7 +14,7 @@ crate struct CanonicalStrand<C: Context> {
 crate struct Strand<'table, C: Context + 'table, I: InferenceContext<C> + 'table> {
     crate infer: &'table mut dyn InferenceTable<C, I>,
 
-    pub(super) ex_clause: ExClause<C, I>,
+    pub(super) ex_clause: ExClause<I>,
 
     /// Index into `ex_clause.subgoals`.
     crate selected_subgoal: Option<SelectedSubgoal<C>>,

--- a/chalk-engine/src/strand.rs
+++ b/chalk-engine/src/strand.rs
@@ -1,6 +1,6 @@
 use std::fmt::{Debug, Error, Formatter};
 use crate::{ExClause, TableIndex};
-use crate::context::{Context, InferenceContext, InferenceTable};
+use crate::context::{Context, InferenceTable};
 use crate::table::AnswerIndex;
 
 #[derive(Debug)]
@@ -11,7 +11,7 @@ crate struct CanonicalStrand<C: Context> {
     crate selected_subgoal: Option<SelectedSubgoal<C>>,
 }
 
-crate struct Strand<'table, C: Context + 'table, I: InferenceContext<C> + 'table> {
+crate struct Strand<'table, C: Context + 'table, I: Context + 'table> {
     crate infer: &'table mut dyn InferenceTable<C, I>,
 
     pub(super) ex_clause: ExClause<I>,
@@ -36,7 +36,7 @@ crate struct SelectedSubgoal<C: Context> {
     crate universe_map: C::UniverseMap,
 }
 
-impl<'table, C: Context, I: InferenceContext<C>> Debug for Strand<'table, C, I> {
+impl<'table, C: Context, I: Context> Debug for Strand<'table, C, I> {
     fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
         fmt.debug_struct("Strand")
             .field("ex_clause", &self.ex_clause)

--- a/chalk-engine/src/table.rs
+++ b/chalk-engine/src/table.rs
@@ -42,9 +42,9 @@ index_struct! {
 /// goal for a particular table (modulo delayed literals). It contains
 /// a substitution
 #[derive(Clone, Debug)]
-pub struct Answer<E: ExClauseContext> {
-    crate subst: E::CanonicalConstrainedSubst,
-    crate delayed_literals: DelayedLiteralSet<E>,
+pub struct Answer<C: Context> {
+    crate subst: C::CanonicalConstrainedSubst,
+    crate delayed_literals: DelayedLiteralSet<C>,
 }
 
 impl<C: Context> Table<C> {

--- a/chalk-engine/src/table.rs
+++ b/chalk-engine/src/table.rs
@@ -42,9 +42,9 @@ index_struct! {
 /// goal for a particular table (modulo delayed literals). It contains
 /// a substitution
 #[derive(Clone, Debug)]
-pub struct Answer<C: Context> {
-    crate subst: C::CanonicalConstrainedSubst,
-    crate delayed_literals: DelayedLiteralSet<C>,
+pub struct Answer<E: ExClauseContext> {
+    crate subst: E::CanonicalConstrainedSubst,
+    crate delayed_literals: DelayedLiteralSet<E>,
 }
 
 impl<C: Context> Table<C> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@
 #![feature(specialization)]
 #![feature(step_trait)]
 #![feature(non_modrs_mods)]
+#![feature(underscore_imports)]
 
 extern crate chalk_parse;
 #[macro_use]

--- a/src/solve/slg/implementation.rs
+++ b/src/solve/slg/implementation.rs
@@ -49,13 +49,6 @@ impl SlgContext {
     }
 }
 
-impl context::ExClauseContext for SlgContext {
-    type CanonicalConstrainedSubst = Canonical<ConstrainedSubst>;
-    type GoalInEnvironment = InEnvironment<Goal>;
-    type Substitution = Substitution;
-    type RegionConstraint = InEnvironment<Constraint>;
-}
-
 impl context::Context for SlgContext {
     type CanonicalGoalInEnvironment = Canonical<InEnvironment<Goal>>;
     type CanonicalExClause = Canonical<ExClause<Self>>;
@@ -63,6 +56,17 @@ impl context::Context for SlgContext {
     type UniverseMap = UniverseMap;
     type InferenceNormalizedSubst = Substitution;
     type Solution = Solution;
+    type Environment = Arc<Environment>;
+    type DomainGoal = DomainGoal;
+    type Goal = Goal;
+    type BindersGoal = Binders<Box<Goal>>;
+    type Parameter = Parameter;
+    type ProgramClause = ProgramClause;
+    type UnificationResult = UnificationResult;
+    type CanonicalConstrainedSubst = Canonical<ConstrainedSubst>;
+    type GoalInEnvironment = InEnvironment<Goal>;
+    type Substitution = Substitution;
+    type RegionConstraint = InEnvironment<Constraint>;
 }
 
 impl context::ContextOps<SlgContext> for SlgContext {
@@ -170,14 +174,6 @@ impl context::TruncateOps<SlgContext, SlgContext> for TruncatingInferenceTable {
 impl context::InferenceTable<SlgContext, SlgContext> for TruncatingInferenceTable {}
 
 impl context::InferenceContext<SlgContext> for SlgContext {
-    type Environment = Arc<Environment>;
-    type DomainGoal = DomainGoal;
-    type Goal = Goal;
-    type BindersGoal = Binders<Box<Goal>>;
-    type Parameter = Parameter;
-    type ProgramClause = ProgramClause;
-    type UnificationResult = UnificationResult;
-
     fn goal_in_environment(environment: &Arc<Environment>, goal: Goal) -> InEnvironment<Goal> {
         InEnvironment::new(environment, goal)
     }
@@ -190,7 +186,7 @@ impl context::InferenceContext<SlgContext> for SlgContext {
         Goal::CannotProve(())
     }
 
-    fn into_hh_goal(goal: Self::Goal) -> HhGoal<SlgContext, Self> {
+    fn into_hh_goal(goal: Self::Goal) -> HhGoal<Self> {
         match goal {
             Goal::Quantified(QuantifierKind::ForAll, binders_goal) => HhGoal::ForAll(binders_goal),
             Goal::Quantified(QuantifierKind::Exists, binders_goal) => HhGoal::Exists(binders_goal),

--- a/src/solve/slg/implementation.rs
+++ b/src/solve/slg/implementation.rs
@@ -62,6 +62,7 @@ impl context::Context for SlgContext {
     type BindersGoal = Binders<Box<Goal>>;
     type Parameter = Parameter;
     type ProgramClause = ProgramClause;
+    type ProgramClauses = Vec<ProgramClause>;
     type UnificationResult = UnificationResult;
     type CanonicalConstrainedSubst = Canonical<ConstrainedSubst>;
     type GoalInEnvironment = InEnvironment<Goal>;

--- a/src/solve/slg/implementation.rs
+++ b/src/solve/slg/implementation.rs
@@ -49,12 +49,18 @@ impl SlgContext {
     }
 }
 
+impl context::ExClauseContext for SlgContext {
+    type CanonicalConstrainedSubst = Canonical<ConstrainedSubst>;
+    type GoalInEnvironment = InEnvironment<Goal>;
+    type Substitution = Substitution;
+    type RegionConstraint = InEnvironment<Constraint>;
+}
+
 impl context::Context for SlgContext {
     type CanonicalGoalInEnvironment = Canonical<InEnvironment<Goal>>;
-    type CanonicalExClause = Canonical<ExClause<Self, Self>>;
+    type CanonicalExClause = Canonical<ExClause<Self>>;
     type UCanonicalGoalInEnvironment = UCanonical<InEnvironment<Goal>>;
     type UniverseMap = UniverseMap;
-    type CanonicalConstrainedSubst = Canonical<ConstrainedSubst>;
     type InferenceNormalizedSubst = Substitution;
     type Solution = Solution;
 }
@@ -78,7 +84,7 @@ impl context::ContextOps<SlgContext> for SlgContext {
     fn instantiate_ex_clause<R>(
         &self,
         num_universes: usize,
-        canonical_ex_clause: &Canonical<ExClause<SlgContext, SlgContext>>,
+        canonical_ex_clause: &Canonical<ExClause<SlgContext>>,
         op: impl context::WithInstantiatedExClause<Self, Output = R>,
     ) -> R {
         let (infer, _subst, ex_cluse) =
@@ -88,7 +94,7 @@ impl context::ContextOps<SlgContext> for SlgContext {
     }
 
     fn inference_normalized_subst_from_ex_clause(
-        canon_ex_clause: &Canonical<ExClause<SlgContext, SlgContext>>,
+        canon_ex_clause: &Canonical<ExClause<SlgContext>>,
     ) -> &Substitution {
         &canon_ex_clause.value.subst
     }
@@ -163,12 +169,6 @@ impl context::TruncateOps<SlgContext, SlgContext> for TruncatingInferenceTable {
 
 impl context::InferenceTable<SlgContext, SlgContext> for TruncatingInferenceTable {}
 
-impl context::ExClauseContext<SlgContext> for SlgContext {
-    type GoalInEnvironment = InEnvironment<Goal>;
-    type Substitution = Substitution;
-    type RegionConstraint = InEnvironment<Constraint>;
-}
-
 impl context::InferenceContext<SlgContext> for SlgContext {
     type Environment = Arc<Environment>;
     type DomainGoal = DomainGoal;
@@ -205,7 +205,7 @@ impl context::InferenceContext<SlgContext> for SlgContext {
 
     fn into_ex_clause(
         result: Self::UnificationResult,
-        ex_clause: &mut ExClause<SlgContext, SlgContext>,
+        ex_clause: &mut ExClause<SlgContext>,
     ) {
         ex_clause
             .subgoals
@@ -253,7 +253,7 @@ impl context::UnificationOps<SlgContext, SlgContext> for TruncatingInferenceTabl
 
     fn debug_ex_clause(
         &mut self,
-        value: &'v ExClause<SlgContext, SlgContext>,
+        value: &'v ExClause<SlgContext>,
     ) -> Box<dyn Debug + 'v> {
         Box::new(self.infer.normalize_deep(value))
     }
@@ -264,8 +264,8 @@ impl context::UnificationOps<SlgContext, SlgContext> for TruncatingInferenceTabl
 
     fn canonicalize_ex_clause(
         &mut self,
-        value: &ExClause<SlgContext, SlgContext>,
-    ) -> Canonical<ExClause<SlgContext, SlgContext>> {
+        value: &ExClause<SlgContext>,
+    ) -> Canonical<ExClause<SlgContext>> {
         self.infer.canonicalize(value).quantified
     }
 
@@ -304,6 +304,18 @@ impl context::UnificationOps<SlgContext, SlgContext> for TruncatingInferenceTabl
         b: &Parameter,
     ) -> Fallible<UnificationResult> {
         self.infer.unify(environment, a, b)
+    }
+
+    /// Since we do not have distinct types for the inference context and the slg-context,
+    /// these conversion operations are just no-ops.q
+    fn sink_answer_subset(&self, c: &Canonical<ConstrainedSubst>) -> Canonical<ConstrainedSubst> {
+        c.clone()
+    }
+
+    /// Since we do not have distinct types for the inference context and the slg-context,
+    /// these conversion operations are just no-ops.q
+    fn lift_delayed_literal(&self, c: DelayedLiteral<SlgContext>) -> DelayedLiteral<SlgContext> {
+        c
     }
 }
 
@@ -453,7 +465,7 @@ impl MayInvalidate {
     }
 }
 
-type ExClauseSlgContext = ExClause<SlgContext, SlgContext>;
+type ExClauseSlgContext = ExClause<SlgContext>;
 struct_fold!(ExClauseSlgContext {
     subst,
     delayed_literals,
@@ -461,7 +473,7 @@ struct_fold!(ExClauseSlgContext {
     subgoals,
 });
 
-type LiteralSlgContext = Literal<SlgContext, SlgContext>;
+type LiteralSlgContext = Literal<SlgContext>;
 enum_fold!(LiteralSlgContext {
     Literal :: {
         Positive(a), Negative(a)

--- a/src/solve/slg/implementation/resolvent.rs
+++ b/src/solve/slg/implementation/resolvent.rs
@@ -3,10 +3,10 @@ use crate::fold::shift::Shift;
 use crate::fold::Fold;
 use crate::ir::*;
 use crate::solve::infer::InferenceTable;
-use crate::solve::slg::implementation::{SlgContext, TruncatingInferenceTable};
+use crate::solve::slg::implementation::{self, SlgContext, TruncatingInferenceTable};
 use crate::zip::{Zip, Zipper};
 
-use chalk_engine::context::{self, InferenceContext};
+use chalk_engine::context;
 use chalk_engine::{ExClause, Literal};
 use std::sync::Arc;
 
@@ -105,7 +105,7 @@ impl context::ResolventOps<SlgContext, SlgContext> for TruncatingInferenceTable 
         };
 
         // Add the subgoals/region-constraints that unification gave us.
-        SlgContext::into_ex_clause(unification_result, &mut ex_clause);
+        implementation::into_ex_clause(unification_result, &mut ex_clause);
 
         // Add the `conditions` from the program clause into the result too.
         ex_clause
@@ -293,7 +293,7 @@ impl<'t> AnswerSubstitutor<'t> {
                 )
             });
 
-        SlgContext::into_ex_clause(
+        implementation::into_ex_clause(
             self.table
                 .unify(&self.environment, answer_param, pending_shifted)?,
             &mut self.ex_clause,

--- a/src/solve/slg/implementation/resolvent.rs
+++ b/src/solve/slg/implementation/resolvent.rs
@@ -61,7 +61,7 @@ impl context::ResolventOps<SlgContext, SlgContext> for TruncatingInferenceTable 
         goal: &DomainGoal,
         subst: &Substitution,
         clause: &ProgramClause,
-    ) -> Fallible<Canonical<ExClause<SlgContext, SlgContext>>> {
+    ) -> Fallible<Canonical<ExClause<SlgContext>>> {
         // Relating the above description to our situation:
         //
         // - `goal` G, except with binders for any existential variables.
@@ -202,11 +202,11 @@ impl context::ResolventOps<SlgContext, SlgContext> for TruncatingInferenceTable 
 
     fn apply_answer_subst(
         &mut self,
-        ex_clause: ExClause<SlgContext, SlgContext>,
+        ex_clause: ExClause<SlgContext>,
         selected_goal: &InEnvironment<Goal>,
         answer_table_goal: &Canonical<InEnvironment<Goal>>,
         canonical_answer_subst: &Canonical<ConstrainedSubst>,
-    ) -> Fallible<ExClause<SlgContext, SlgContext>> {
+    ) -> Fallible<ExClause<SlgContext>> {
         debug_heading!("apply_answer_subst()");
         debug!("ex_clause={:?}", ex_clause);
         debug!(
@@ -247,7 +247,7 @@ struct AnswerSubstitutor<'t> {
     answer_subst: &'t Substitution,
     answer_binders: usize,
     pending_binders: usize,
-    ex_clause: ExClause<SlgContext, SlgContext>,
+    ex_clause: ExClause<SlgContext>,
 }
 
 impl<'t> AnswerSubstitutor<'t> {
@@ -255,10 +255,10 @@ impl<'t> AnswerSubstitutor<'t> {
         table: &mut InferenceTable,
         environment: &Arc<Environment>,
         answer_subst: &Substitution,
-        ex_clause: ExClause<SlgContext, SlgContext>,
+        ex_clause: ExClause<SlgContext>,
         answer: &T,
         pending: &T,
-    ) -> Fallible<ExClause<SlgContext, SlgContext>> {
+    ) -> Fallible<ExClause<SlgContext>> {
         let mut this = AnswerSubstitutor {
             table,
             environment,


### PR DESCRIPTION
Refactor the context traits to allow rustc to implement them. The key change is that all the types go into one `Context` trait which offers nothing but types (well, and a few very simple helper methods). This means that, on the rustc side, we can implement `Context` with a type like

```rust
struct ChalkContext<'tcx> { PhantomData<&'tcx ()> }
```

This in turn means that types like `ExClause<ChalkContext<'tcx>>` are effectively the same (contravariant in the lifetime `'tcx`, etc) as other rustc types like `Ty<'tcx>` and so forth. This unlocks the ability to implement the `Lift` and other traits we need. 

Plus, I think this setup is ultimately simpler on the chalk side, since we don't have annoying things like `ExClause<C, I>`. The main downside is that we need some lift and conversion methods here and there.

r? @scalexm or @leodasvacas 