### PR TITLE
fewer deps for cargo-engine

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -82,7 +82,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "chalk"
 version = "0.1.0"
 dependencies = [
- "chalk-engine 0.3.0",
+ "chalk-engine 0.4.0",
  "chalk-macros 0.1.0",
  "chalk-parse 0.1.0",
  "diff 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -100,21 +100,10 @@ dependencies = [
 
 [[package]]
 name = "chalk-engine"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "chalk-macros 0.1.0",
- "diff 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "docopt 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "ena 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fxhash 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "itertools 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "lalrpop-intern 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "petgraph 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustyline 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "stacker 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/chalk-engine/Cargo.toml
+++ b/chalk-engine/Cargo.toml
@@ -9,17 +9,6 @@ readme = "README.md"
 keywords = ["compiler", "traits", "prolog"]
 
 [dependencies]
-diff = "0.1.11"
-docopt = "0.8.1"
-ena = "0.4"
-error-chain = "0.11.0"
-itertools = "0.6.0"
-lalrpop-intern = "0.14"
-lazy_static = "0.2.2"
-petgraph = "0.4.5"
-rustyline = "1.0"
-serde = "1.0"
-serde_derive = "1.0"
 stacker = "0.1.2"
 fxhash = "0.2.1"
 


### PR DESCRIPTION
I'd still like to move `fxhash` and `stacker` behind a feature flag, I think (maybe a on-by-default flag that rustc can opt out of)