### PR TITLE
Finish implementing GATs

### DIFF
--- a/chalk-parse/src/ast.rs
+++ b/chalk-parse/src/ast.rs
@@ -86,7 +86,7 @@ pub struct TraitBound {
 pub struct ProjectionEqBound {
     pub trait_bound: TraitBound,
     pub name: Identifier,
-    pub parameters: Vec<Parameter>,
+    pub args: Vec<Parameter>,
     pub value: Ty,
 }
 

--- a/chalk-parse/src/parser.lalrpop
+++ b/chalk-parse/src/parser.lalrpop
@@ -107,7 +107,7 @@ ProjectionEqBound: ProjectionEqBound = {
             args_no_self: a.unwrap_or(vec![]),
         },
         name,
-        parameters: a2,
+        args: a2,
         value: ty,
     }
 };

--- a/src/fold.rs
+++ b/src/fold.rs
@@ -431,6 +431,7 @@ enum_fold!(Constraint[] { LifetimeEq(a, b) });
 enum_fold!(Goal[] { Quantified(qkind, subgoal), Implies(wc, subgoal), And(g1, g2), Not(g),
                     Leaf(wc), CannotProve(a) });
 enum_fold!(ProgramClause[] { Implies(a), ForAll(a) });
+enum_fold!(InlineBound[] { TraitBound(a), ProjectionEqBound(a) });
 
 macro_rules! struct_fold {
     ($s:ident $([$($tt_args:tt)*])? { $($name:ident),* $(,)* } $($w:tt)*) => {
@@ -580,6 +581,18 @@ struct_fold!(ProgramClauseImplication {
 struct_fold!(ConstrainedSubst {
     subst, /* NB: The `is_trivial` routine relies on the fact that `subst` is folded first. */
     constraints,
+});
+
+struct_fold!(TraitBound {
+    trait_id,
+    args_no_self,
+});
+
+struct_fold!(ProjectionEqBound {
+    trait_bound,
+    associated_ty_id,
+    parameters,
+    value,
 });
 
 // struct_fold!(ApplicationTy { name, parameters }); -- intentionally omitted, folded through Ty

--- a/src/ir.rs
+++ b/src/ir.rs
@@ -258,6 +258,32 @@ pub struct TraitFlags {
     pub deref: bool,
 }
 
+/// An inline bound, e.g. `: Foo<K>` in `impl<K, T: Foo<K>> SomeType<T>`.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub enum InlineBound {
+    TraitBound(TraitBound),
+    ProjectionEqBound(ProjectionEqBound),
+}
+
+/// Represents a trait bound on e.g. a type or type parameter.
+/// Does not know anything about what it's binding.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct TraitBound {
+    crate trait_id: ItemId,
+    crate args_no_self: Vec<Parameter>,
+}
+
+/// Represents a projection equality bound on e.g. a type or type parameter.
+/// Does not know anything about what it's binding.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct ProjectionEqBound {
+    crate trait_bound: TraitBound,
+    crate associated_ty_id: ItemId,
+    /// Does not include trait parameters.
+    crate parameters: Vec<Parameter>,
+    crate value: Ty,
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct AssociatedTyDatum {
     /// The trait this associated type is defined in.
@@ -273,7 +299,11 @@ pub struct AssociatedTyDatum {
     /// but possibly including more.
     crate parameter_kinds: Vec<ParameterKind<Identifier>>,
 
-    // FIXME: inline bounds on the associated ty need to be implemented
+    /// Bounds on the associated type itself.
+    ///
+    /// These must be proven by the implementer, for all possible parameters that
+    /// would result in a well-formed projection.
+    crate bounds: Vec<InlineBound>,
 
     /// Where clauses that must hold for the projection be well-formed.
     crate where_clauses: Vec<QuantifiedDomainGoal>,

--- a/src/ir.rs
+++ b/src/ir.rs
@@ -693,7 +693,9 @@ impl DomainGoal {
     /// Same as `into_well_formed_goal` but with the `FromEnv` predicate instead of `WellFormed`.
     crate fn into_from_env_goal(self) -> DomainGoal {
         match self {
-            DomainGoal::Holds(wca) => DomainGoal::FromEnv(wca),
+            DomainGoal::Holds(wca @ WhereClauseAtom::Implemented(..)) => {
+                DomainGoal::FromEnv(wca)
+            }
             goal => goal,
         }
     }

--- a/src/ir.rs
+++ b/src/ir.rs
@@ -269,9 +269,9 @@ pub enum InlineBound {
 impl InlineBound {
     /// Applies the `InlineBound` to `self_ty` and lowers to a [`DomainGoal`].
     /// 
-    /// Because an `InlineBound` not know anything about what it's binding, you
-    /// must provide that type as `self_ty`.
-    pub fn lower_with_self(&self, self_ty: Ty) -> Vec<DomainGoal> {
+    /// Because an `InlineBound` does not know anything about what it's binding,
+    /// you must provide that type as `self_ty`.
+    crate fn lower_with_self(&self, self_ty: Ty) -> Vec<DomainGoal> {
         match self {
             InlineBound::TraitBound(b) => b.lower_with_self(self_ty),
             InlineBound::ProjectionEqBound(b) => b.lower_with_self(self_ty),
@@ -288,7 +288,7 @@ pub struct TraitBound {
 }
 
 impl TraitBound {
-    pub fn lower_with_self(&self, self_ty: Ty) -> Vec<DomainGoal> {
+    crate fn lower_with_self(&self, self_ty: Ty) -> Vec<DomainGoal> {
         let trait_ref = self.as_trait_ref(self_ty);
         vec![DomainGoal::Holds(WhereClauseAtom::Implemented(trait_ref))]
     }
@@ -314,7 +314,7 @@ pub struct ProjectionEqBound {
 }
 
 impl ProjectionEqBound {
-    pub fn lower_with_self(&self, self_ty: Ty) -> Vec<DomainGoal> {
+    crate fn lower_with_self(&self, self_ty: Ty) -> Vec<DomainGoal> {
         let trait_ref = self.trait_bound.as_trait_ref(self_ty);
 
         let mut parameters = self.parameters.clone();
@@ -354,7 +354,7 @@ pub struct AssociatedTyDatum {
     /// would result in a well-formed projection.
     crate bounds: Vec<InlineBound>,
 
-    /// Where clauses that must hold for the projection be well-formed.
+    /// Where clauses that must hold for the projection to be well-formed.
     crate where_clauses: Vec<QuantifiedDomainGoal>,
 }
 
@@ -364,7 +364,7 @@ impl AssociatedTyDatum {
     /// ```notrust
     /// Implemented(<?0 as Foo>::Item<?1>: Sized)
     /// ```
-    pub fn bounds_on_self(&self) -> Vec<DomainGoal> {
+    crate fn bounds_on_self(&self) -> Vec<DomainGoal> {
         let parameters = self.parameter_kinds
                              .anonymize()
                              .iter()

--- a/src/ir/lowering/test.rs
+++ b/src/ir/lowering/test.rs
@@ -228,7 +228,14 @@ fn atc_accounting() {
         println!("{}", goal_text);
         assert_eq!(
             goal_text,
-            "ForAll<type> { ForAll<lifetime> { ForAll<type> { ProjectionEq(<?2 as Iterable>::Iter<'?1> = ?0) } } }"
+            "ForAll<type> { \
+                ForAll<lifetime> { \
+                    ForAll<type> { \
+                        (ProjectionEq(<?2 as Iterable>::Iter<'?1> = ?0), \
+                        Implemented(?2: Iterable)) \
+                    } \
+                } \
+            }"
         );
     });
 }

--- a/src/ir/lowering/test.rs
+++ b/src/ir/lowering/test.rs
@@ -378,3 +378,31 @@ fn duplicate_parameters() {
         }
     }
 }
+
+#[test]
+fn external_items() {
+    lowering_success! {
+        program {
+            extern trait Send { }
+            extern struct Vec<T> { }
+        }
+    }
+}
+
+#[test]
+fn deref_trait() {
+    lowering_success! {
+        program {
+            #[lang_deref] trait Deref { type Target; }
+        }
+    }
+
+    lowering_error! {
+        program {
+            #[lang_deref] trait Deref { }
+            #[lang_deref] trait DerefDupe { }
+        } error_msg {
+            "Duplicate lang item `DerefTrait`"
+        }
+    }
+}

--- a/src/ir/lowering/test.rs
+++ b/src/ir/lowering/test.rs
@@ -315,6 +315,7 @@ fn gat_parse() {
     lowering_success! {
         program {
             trait Sized {}
+            trait Clone {}
 
             trait Foo {
                 type Item<'a, T>: Sized + Clone where Self: Sized;

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -237,7 +237,7 @@ impl ir::AssociatedTyValue {
         let projection = ir::ProjectionTy {
             associated_ty_id: self.associated_ty_id,
 
-            // Add the remaining parameters of the trait-ref if any
+            // Add the remaining parameters of the trait-ref, if any
             parameters: parameters.iter()
                                   .chain(&impl_trait_ref.parameters[1..])
                                   .cloned()
@@ -528,10 +528,7 @@ impl ir::AssociatedTyDatum {
         }.cast());
 
         // Assuming well-formedness of projection type means we can assume
-        // the trait ref as well.
-        //
-        // Currently we do not use this rule in chalk (it's used in fn bodies),
-        // but it's here for completeness.
+        // the trait ref as well. Mostly used in function bodies.
         //
         //    forall<Self> {
         //        FromEnv(Self: Foo) :- FromEnv((Foo::Assoc)<Self>).

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -536,11 +536,12 @@ impl ir::AssociatedTyDatum {
         //
         // This is really a family of clauses, one for each where clause.
         clauses.extend(self.where_clauses.iter().map(|wc| {
+            let shift = wc.binders.len();
             ir::Binders {
-                binders: binders.iter().chain(wc.binders.iter()).cloned().collect(),
+                binders: wc.binders.iter().chain(binders.iter()).cloned().collect(),
                 value: ir::ProgramClauseImplication {
                     consequence: wc.value.clone().into_from_env_goal(),
-                    conditions: vec![ir::DomainGoal::FromEnvTy(app_ty.clone()).cast()],
+                    conditions: vec![ir::DomainGoal::FromEnvTy(app_ty.clone()).up_shift(shift).cast()],
                 }
             }.cast()
         }));

--- a/src/rules/wf.rs
+++ b/src/rules/wf.rs
@@ -325,7 +325,7 @@ impl WfSolver {
         let goal = Goal::Implies(hypotheses, Box::new(goal))
             .quantify(QuantifierKind::ForAll, impl_datum.binders.binders.clone());
 
-        println!("{:?}", goal);
+        debug!("WF trait goal: {:?}", goal);
 
         match self.solver_choice.solve_root_goal(&self.env, &goal.into_closed_goal()).unwrap() {
             Some(sol) => sol.is_unique(),

--- a/src/rules/wf.rs
+++ b/src/rules/wf.rs
@@ -5,6 +5,8 @@ use errors::*;
 use cast::*;
 use solve::SolverChoice;
 use itertools::Itertools;
+use fold::*;
+use fold::shift::Shift;
 
 mod test;
 
@@ -209,13 +211,11 @@ impl WfSolver {
         let mut input_types = Vec::new();
         impl_datum.binders.value.where_clauses.fold(&mut input_types);
 
-        // We partition the input types of the type on which we implement the trait in two categories:
-        // * projection types, e.g. `<T as Iterator>::Item`: we will have to prove that these types
-        //   are well-formed, e.g. that we can show that `T: Iterator` holds
-        // * any other types, e.g. `HashSet<K>`: we will *assume* that these types are well-formed, e.g.
-        //   we will be able to derive that `K: Hash` holds without writing any where clause.
+        // We retrieve all the input types of the type on which we implement the trait: we will
+        // *assume* that these types are well-formed, e.g. we will be able to derive that
+        // `K: Hash` holds without writing any where clause.
         //
-        // Examples:
+        // Example:
         // ```
         // struct HashSet<K> where K: Hash { ... }
         //
@@ -223,24 +223,8 @@ impl WfSolver {
         //     // Inside here, we can rely on the fact that `K: Hash` holds
         // }
         // ```
-        //
-        // ```
-        // impl<T> Foo for <T as Iterator>::Item {
-        //     // The impl is not well-formed, as an exception we do not assume that
-        //     // `<T as Iterator>::Item` is well-formed and instead want to prove it.
-        // }
-        // ```
-        //
-        // ```
-        // impl<T> Foo for <T as Iterator>::Item where T: Iterator {
-        //     // Now ok.
-        // }
-        // ```
         let mut header_input_types = Vec::new();
         trait_ref.fold(&mut header_input_types);
-        let (header_projection_types, header_other_types): (Vec<_>, Vec<_>) =
-            header_input_types.into_iter()
-                              .partition(|ty| ty.is_projection());
 
         // Associated type values are special because they can be parametric (independently of
         // the impl), so we issue a special goal which is quantified using the binders of the
@@ -259,49 +243,48 @@ impl WfSolver {
             let assoc_ty_datum = &self.env.associated_ty_data[&assoc_ty.associated_ty_id];
             let bounds = &assoc_ty_datum.bounds;
 
-            let trait_datum = &self.env.trait_data[&assoc_ty_datum.trait_id];
-
             let mut input_types = Vec::new();
             assoc_ty.value.value.ty.fold(&mut input_types);
 
-            let goals = input_types.into_iter()
-                                   .map(|ty| DomainGoal::WellFormedTy(ty).cast());
-                                   //.chain(bounds.iter()
-                                   //             .flat_map(|b| b.clone()
-                                   //                            .lower_with_self(assoc_ty.value.value.ty.clone()))
-                                   //             .map(|g| g.into_well_formed_goal().cast()));
-            let goal = goals.fold1(|goal, leaf| Goal::And(Box::new(goal), Box::new(leaf)));
-                            //.expect("at least one goal");
-            let goal = goal //Goal::Implies(hypotheses, Box::new(goal))
-                .map(|goal| goal.quantify(QuantifierKind::ForAll, assoc_ty.value.binders.clone()));//binders);
+            let wf_goals =
+                input_types.into_iter()
+                           .map(|ty| DomainGoal::WellFormedTy(ty));
+            
+            let trait_ref = trait_ref.up_shift(assoc_ty.value.binders.len());
 
-            // FIXME this is wrong (and test)!
-            let mut bound_binders = assoc_ty.value.binders.clone();
-            bound_binders.extend(trait_datum.binders.binders.iter());
+            let all_parameters: Vec<_> =
+                assoc_ty.value.binders.iter()
+                                      .zip(0..)
+                                      .map(|p| p.to_parameter())
+                                      .chain(trait_ref.parameters.iter().cloned())
+                                      .collect();
+            
+            let bound_goals =
+                bounds.iter()
+                      .map(|b| Subst::apply(&all_parameters, b))
+                      .flat_map(|b| b.lower_with_self(assoc_ty.value.value.ty.clone()))
+                      .map(|g| g.into_well_formed_goal());
+            
+            let goals = wf_goals.chain(bound_goals).casted();
+            let goal = match goals.fold1(|goal, leaf| Goal::And(Box::new(goal), Box::new(leaf))) {
+                Some(goal) => goal,
+                None => return None,
+            };
 
             let hypotheses =
                 assoc_ty_datum.where_clauses
                               .iter()
-                              .chain(impl_datum.binders.value.where_clauses.iter())  // FIXME binders (and test)!
-                              .cloned()
+                              .map(|wc| Subst::apply(&all_parameters, wc))
                               .map(|wc| wc.map(|bound| bound.into_from_env_goal()))
                               .casted()
                               .collect();
-            let bound_goal = bounds.iter()
-                                   .flat_map(|b| b.clone()
-                                   .lower_with_self(assoc_ty.value.value.ty.clone()))
-                                   .map(|g| g.into_well_formed_goal().cast())
-                                   .fold1(|goal, leaf| Goal::And(Box::new(goal), Box::new(leaf)));
-            let bound_goal = bound_goal.map(|g| {
-                Goal::Implies(hypotheses, Box::new(g)).quantify(QuantifierKind::ForAll, bound_binders)
-            });
+            
+            let goal = Goal::Implies(
+                hypotheses,
+                Box::new(goal)
+            );
 
-            let goal = goal.into_iter()
-                           .chain(bound_goal.into_iter())
-                           .fold1(|goal, leaf| Goal::And(Box::new(goal), Box::new(leaf)));
-            println!("{:?}", goal);
-
-            goal
+            Some(goal.quantify(QuantifierKind::ForAll, assoc_ty.value.binders.clone()))
         };
 
         let assoc_ty_goals =
@@ -318,7 +301,6 @@ impl WfSolver {
         );
         let goals =
             input_types.into_iter()
-                       .chain(header_projection_types.into_iter())
                        .map(|ty| DomainGoal::WellFormedTy(ty).cast())
                        .chain(assoc_ty_goals)
                        .chain(Some(trait_ref_wf).cast());
@@ -337,11 +319,13 @@ impl WfSolver {
                       .cloned()
                       .map(|wc| wc.map(|bound| bound.into_from_env_goal()))
                       .casted()
-                      .chain(header_other_types.into_iter().map(|ty| DomainGoal::FromEnvTy(ty).cast()))
+                      .chain(header_input_types.into_iter().map(|ty| DomainGoal::FromEnvTy(ty).cast()))
                       .collect();
 
         let goal = Goal::Implies(hypotheses, Box::new(goal))
             .quantify(QuantifierKind::ForAll, impl_datum.binders.binders.clone());
+
+        println!("{:?}", goal);
 
         match self.solver_choice.solve_root_goal(&self.env, &goal.into_closed_goal()).unwrap() {
             Some(sol) => sol.is_unique(),

--- a/src/rules/wf.rs
+++ b/src/rules/wf.rs
@@ -258,7 +258,9 @@ impl WfSolver {
                                       .map(|p| p.to_parameter())
                                       .chain(trait_ref.parameters.iter().cloned())
                                       .collect();
-            
+
+            // Add bounds from the trait. Because they are defined on the trait,
+            // their parameters must be substituted with those of the impl.
             let bound_goals =
                 bounds.iter()
                       .map(|b| Subst::apply(&all_parameters, b))
@@ -271,6 +273,8 @@ impl WfSolver {
                 None => return None,
             };
 
+            // Add where clauses from the associated ty definition. We must
+            // substitute parameters here, like we did with the bounds above.
             let hypotheses =
                 assoc_ty_datum.where_clauses
                               .iter()
@@ -278,7 +282,7 @@ impl WfSolver {
                               .map(|wc| wc.map(|bound| bound.into_from_env_goal()))
                               .casted()
                               .collect();
-            
+
             let goal = Goal::Implies(
                 hypotheses,
                 Box::new(goal)

--- a/src/rules/wf/test.rs
+++ b/src/rules/wf/test.rs
@@ -439,16 +439,6 @@ fn generic_projection_bound() {
 }
 
 #[test]
-fn external_items() {
-    lowering_success! {
-        program {
-            extern trait Send { }
-            extern struct Vec<T> { }
-        }
-    }
-}
-
-#[test]
 fn higher_ranked_trait_bounds() {
     lowering_error! {
         program {
@@ -470,6 +460,24 @@ fn higher_ranked_trait_bounds() {
 
             impl<'a> Foo<'a> for i32 { }
             impl Bar for i32 { }
+        }
+    }
+}
+
+#[test]
+fn higher_ranked_trait_bound_on_gat() {
+    lowering_success! {
+        program {
+            trait Foo<'a> { }
+            struct i32 { }
+
+            trait Bar<'a> {
+                type Item<V>: Foo<'a> where forall<'b> V: Foo<'b>;
+            }
+
+            impl<'a> Bar<'a> for i32 {
+                type Item<V> = V;
+            }
         }
     }
 }
@@ -508,24 +516,6 @@ fn higher_ranked_cyclic_requirements() {
 
             impl<T, U> Foo<T> for U where U: Copy { }
             impl<T, U> Bar<T> for U where U: Foo<T> { }
-        }
-    }
-}
-
-#[test]
-fn deref_trait() {
-    lowering_success! {
-        program {
-            #[lang_deref] trait Deref { type Target; }
-        }
-    }
-
-    lowering_error! {
-        program {
-            #[lang_deref] trait Deref { }
-            #[lang_deref] trait DerefDupe { }
-        } error_msg {
-            "Duplicate lang item `DerefTrait`"
         }
     }
 }

--- a/src/solve/test.rs
+++ b/src/solve/test.rs
@@ -740,7 +740,7 @@ fn normalize_gat_with_higher_ranked_trait_bound() {
 }
 
 #[test]
-fn normalize_implied_bound() {
+fn implied_bounds() {
     test! {
         program {
             trait Clone { }
@@ -761,7 +761,7 @@ fn normalize_implied_bound() {
 }
 
 #[test]
-fn normalize_implied_bound_gat() {
+fn gat_implied_bounds() {
     test! {
         program {
             trait Clone { }
@@ -792,6 +792,36 @@ fn normalize_implied_bound_gat() {
                 if (T: Foo<Item<U> = V>) {
                     // Without the bound Item<T>: Clone, there is no way to infer this.
                     V: Clone
+                }
+            }
+        } yields {
+            "No possible solution"
+        }
+    }
+}
+
+#[test]
+fn implied_from_env() {
+    test! {
+        program {
+            trait Clone { }
+            trait Foo<U> { type Item<V>; }
+        }
+
+        goal {
+            forall<T, U, V> {
+                if (FromEnv(<T as Foo<U>>::Item<V>)) {
+                    FromEnv(T: Foo<U>)
+                }
+            }
+        } yields {
+            "Unique"
+        }
+
+        goal {
+            forall<T, U, V> {
+                if (FromEnv(<T as Foo<U>>::Item<V>)) {
+                    FromEnv(T: Clone)
                 }
             }
         } yields {

--- a/src/test_util.rs
+++ b/src/test_util.rs
@@ -22,11 +22,15 @@ macro_rules! lowering_success {
         let program_text = stringify!($program);
         assert!(program_text.starts_with("{"));
         assert!(program_text.ends_with("}"));
+        let result = parse_and_lower_program(
+            &program_text[1..program_text.len()-1],
+            $crate::solve::SolverChoice::slg()
+        );
+        if let Err(ref e) = result {
+            println!("lowering error: {}", e);
+        }
         assert!(
-            parse_and_lower_program(
-                &program_text[1..program_text.len()-1],
-                $crate::solve::SolverChoice::slg()
-            ).is_ok()
+            result.is_ok()
         );
     }
 }


### PR DESCRIPTION
Implement and test logic around Generic Associated Types.

This required shuffling around the logic rules we used. This PR implements the set of rules described in https://github.com/rust-lang-nursery/chalk/issues/12#issuecomment-377258347.

Closes #116.