### PR TITLE
Adding IsLocal DomainGoal and Generating IsLocal clause for all non-external types

### DIFF
--- a/chalk-parse/src/ast.rs
+++ b/chalk-parse/src/ast.rs
@@ -217,6 +217,7 @@ pub enum WhereClause {
     UnifyLifetimes { a: Lifetime, b: Lifetime },
     TraitInScope { trait_name: Identifier },
     Derefs { source: Ty, target: Ty },
+    TyIsLocal { ty: Ty },
 }
 
 pub struct QuantifiedWhereClause {
@@ -247,4 +248,3 @@ pub enum Goal {
     // Additional kinds of goals:
     Leaf(WhereClause),
 }
-

--- a/chalk-parse/src/parser.lalrpop
+++ b/chalk-parse/src/parser.lalrpop
@@ -270,6 +270,8 @@ WhereClause: WhereClause = {
 
     "InScope" "(" <t:Id> ")" => WhereClause::TraitInScope { trait_name: t },
     "Derefs" "(" <source:Ty> "," <target:Ty> ")" => WhereClause::Derefs { source, target },
+
+    "IsLocal" "(" <ty:Ty> ")" => WhereClause::TyIsLocal { ty },
 };
 
 QuantifiedWhereClause: QuantifiedWhereClause = {

--- a/src/fold.rs
+++ b/src/fold.rs
@@ -425,7 +425,7 @@ enum_fold!(PolarizedTraitRef[] { Positive(a), Negative(a) });
 enum_fold!(ParameterKind[T,L] { Ty(a), Lifetime(a) } where T: Fold, L: Fold);
 enum_fold!(WhereClauseAtom[] { Implemented(a), ProjectionEq(a) });
 enum_fold!(DomainGoal[] { Holds(a), WellFormed(a), FromEnv(a), Normalize(a), UnselectedNormalize(a),
-                          WellFormedTy(a), FromEnvTy(a), InScope(a), Derefs(a) });
+                          WellFormedTy(a), FromEnvTy(a), InScope(a), Derefs(a), IsLocalTy(a), IsLocalTraitRef(a) });
 enum_fold!(LeafGoal[] { EqGoal(a), DomainGoal(a) });
 enum_fold!(Constraint[] { LifetimeEq(a, b) });
 enum_fold!(Goal[] { Quantified(qkind, subgoal), Implies(wc, subgoal), And(g1, g2), Not(g),

--- a/src/ir.rs
+++ b/src/ir.rs
@@ -508,7 +508,7 @@ pub enum DomainGoal {
 
     /// A predicate which is true is some trait ref is well-formed.
     /// For example, given the following trait definitions:
-    /// 
+    ///
     /// ```notrust
     /// trait Clone { ... }
     /// trait Copy where Self: Clone { ... }
@@ -550,7 +550,7 @@ pub enum DomainGoal {
     /// A predicate which enables deriving everything which should be true if we *know* that
     /// some type is well-formed. For example given the above type definition, we can use
     /// `FromEnv(Set<K>)` to derive that `K: Hash`, like in:
-    /// 
+    ///
     /// ```notrust
     /// forall<K> {
     ///     if (FromEnv(Set<K>)) {
@@ -567,7 +567,10 @@ pub enum DomainGoal {
     /// Derefs(T, U) :- Implemented(T: Deref<Target = U>)
     /// ```
     /// In Rust there are also raw pointers which can be deref'd but do not implement Deref.
-    Derefs(Derefs)
+    Derefs(Derefs),
+
+    IsLocalTy(Ty),
+    IsLocalTraitRef(TraitRef),
 }
 
 pub type QuantifiedDomainGoal = Binders<DomainGoal>;

--- a/src/ir.rs
+++ b/src/ir.rs
@@ -569,6 +569,9 @@ pub enum DomainGoal {
     /// In Rust there are also raw pointers which can be deref'd but do not implement Deref.
     Derefs(Derefs),
 
+    /// True if a type is considered to have been "defined" by the current crate. This is true for
+    /// a `struct Foo { }` but false for a `extern struct Foo { }`. However, for fundamental types
+    /// like `Box<T>`, it is true if `T` is local.
     IsLocalTy(Ty),
     IsLocalTraitRef(TraitRef),
 }

--- a/src/ir/debug.rs
+++ b/src/ir/debug.rs
@@ -206,6 +206,8 @@ impl Debug for DomainGoal {
             DomainGoal::FromEnvTy(t) => write!(fmt, "FromEnv({:?})", t),
             DomainGoal::InScope(n) => write!(fmt, "InScope({:?})", n),
             DomainGoal::Derefs(n) => write!(fmt, "Derefs({:?})", n),
+            DomainGoal::IsLocalTy(n) => write!(fmt, "IsLocalTy({:?})", n),
+            DomainGoal::IsLocalTraitRef(n) => write!(fmt, "IsLocalTraitRef({:?})", n),
         }
     }
 }

--- a/src/ir/lowering.rs
+++ b/src/ir/lowering.rs
@@ -483,10 +483,13 @@ impl LowerWhereClause<ir::DomainGoal> for WhereClause {
                 ir::DomainGoal::InScope(id)
             }
             WhereClause::Derefs { source, target } => {
-                ir::DomainGoal::Derefs(ir::Derefs { 
-                                        source: source.lower(env)?, 
-                                        target: target.lower(env)?
-                                    })
+                ir::DomainGoal::Derefs(ir::Derefs {
+                    source: source.lower(env)?,
+                    target: target.lower(env)?
+                })
+            }
+            WhereClause::TyIsLocal { ty } => {
+                ir::DomainGoal::IsLocalTy(ty.lower(env)?)
             }
         };
         Ok(vec![goal])
@@ -517,7 +520,8 @@ impl LowerWhereClause<ir::LeafGoal> for WhereClause {
             | WhereClause::TraitRefWellFormed { .. }
             | WhereClause::TyFromEnv { .. }
             | WhereClause::TraitRefFromEnv { .. }
-            | WhereClause::Derefs { .. } => {
+            | WhereClause::Derefs { .. }
+            | WhereClause::TyIsLocal { .. } => {
                 let goals: Vec<ir::DomainGoal> = self.lower(env)?;
                 goals.into_iter().casted().collect()
             }

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -273,7 +273,7 @@ impl ir::StructDatum {
         //    forall<T> { WF(Foo<T>) :- (T: Eq). }
         //    forall<T> { FromEnv(T: Eq) :- FromEnv(Foo<T>). }
         //
-        // If the type Foo is not marked #[extern], we also generate:
+        // If the type Foo is not marked `extern`, we also generate:
         //
         //    forall<T> { IsLocalTy(Foo<T>) }
 
@@ -293,7 +293,7 @@ impl ir::StructDatum {
 
         let mut clauses = vec![wf];
 
-        // Types that are not marked #[extern] satisfy IsLocal(TypeName)
+        // Types that are not marked `extern` satisfy IsLocal(TypeName)
         if !self.binders.value.flags.external {
             // `IsLocalTy(Ty)` depends *only* on whether the type is marked extern and nothing else
             let is_local = self.binders.map_ref(|bound_datum| ir::ProgramClauseImplication {

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -47,7 +47,7 @@ impl ir::Program {
                 value: ir::ProgramClauseImplication {
                     consequence: ir::DomainGoal::Derefs(ir::Derefs { source: t(), target: u() }),
                     conditions: vec![ir::ProjectionEq {
-                        projection: ir::ProjectionTy { 
+                        projection: ir::ProjectionTy {
                             associated_ty_id,
                             parameters: vec![t().cast()]
                         },
@@ -272,6 +272,10 @@ impl ir::StructDatum {
         //
         //    forall<T> { WF(Foo<T>) :- (T: Eq). }
         //    forall<T> { FromEnv(T: Eq) :- FromEnv(Foo<T>). }
+        //
+        // If the type Foo is not marked #[extern], we also generate:
+        //
+        //    forall<T> { IsLocalTy(Foo<T>) }
 
         let wf = self.binders.map_ref(|bound_datum| {
             ir::ProgramClauseImplication {
@@ -288,6 +292,18 @@ impl ir::StructDatum {
         }).cast();
 
         let mut clauses = vec![wf];
+
+        // Types that are not marked #[extern] satisfy IsLocal(TypeName)
+        if !self.binders.value.flags.external {
+            // `IsLocalTy(Ty)` depends *only* on whether the type is marked extern and nothing else
+            let is_local = self.binders.map_ref(|bound_datum| ir::ProgramClauseImplication {
+                consequence: ir::DomainGoal::IsLocalTy(bound_datum.self_ty.clone().cast()),
+                conditions: Vec::new(),
+            }).cast();
+
+            clauses.push(is_local);
+        }
+
         let condition = ir::DomainGoal::FromEnvTy(self.binders.value.self_ty.clone().cast());
 
         for wc in self.binders
@@ -511,7 +527,7 @@ impl ir::AssociatedTyDatum {
             },
         }.cast());
 
-        
+
         let projection_wc = ir::WhereClauseAtom::ProjectionEq(projection_eq.clone());
         let trait_ref_wc = ir::WhereClauseAtom::Implemented(trait_ref.clone());
 

--- a/src/rules/wf.rs
+++ b/src/rules/wf.rs
@@ -141,6 +141,8 @@ impl FoldInputTypes for DomainGoal {
             DomainGoal::FromEnv(..) |
             DomainGoal::WellFormedTy(..) |
             DomainGoal::FromEnvTy(..) |
+            DomainGoal::IsLocalTy(..) |
+            DomainGoal::IsLocalTraitRef(..) |
             DomainGoal::Derefs(..) => panic!("unexpected where clause"),
 
             DomainGoal::InScope(..) => (),

--- a/src/solve/test.rs
+++ b/src/solve/test.rs
@@ -1935,7 +1935,7 @@ fn projection_from_env_slow() {
 #[test]
 fn clauses_in_if_goals() {
     test! {
-        program { 
+        program {
             trait Foo { }
             struct Vec<T> { }
             struct i32 { }
@@ -2071,7 +2071,7 @@ fn deref_goal() {
             "No possible solution"
         }
     }
-    
+
     test! {
         program {
             #[lang_deref]
@@ -2093,5 +2093,31 @@ fn deref_goal() {
         } yields {
             "No possible solution"
         }
+    }
+}
+
+#[test]
+fn local_and_external_types() {
+    test! {
+        program {
+            extern struct External { }
+            struct Internal { }
+        }
+
+        goal { IsLocal(External) } yields { "No possible solution" }
+
+        goal { IsLocal(Internal) } yields { "Unique" }
+    }
+
+    test! {
+        program {
+            trait Clone { }
+            extern struct External<T> where T: Clone { }
+            struct Internal<T> where T: Clone { }
+        }
+
+        goal { forall<T> { IsLocal(External<T>) } } yields { "No possible solution" }
+
+        goal { forall<T> { IsLocal(Internal<T>) } } yields { "Unique" }
     }
 }

--- a/src/zip.rs
+++ b/src/zip.rs
@@ -226,7 +226,9 @@ enum_zip!(DomainGoal {
     WellFormedTy,
     FromEnvTy,
     InScope,
-    Derefs
+    Derefs,
+    IsLocalTy,
+    IsLocalTraitRef
 });
 enum_zip!(LeafGoal { DomainGoal, EqGoal });
 enum_zip!(ProgramClause { Implies, ForAll });


### PR DESCRIPTION
This PR is relatively small but does several things that all needed to happen at once in order for tests to continue to pass:

1. Added the `IsLocalTy` and `IsLocalTraitRef` domain goals
2. Added parsing for `IsLocal` (just the `Ty` version for now)
   This means that parsing something like `forall<> { IsLocal(Foo) }` works, though this is not tested anywhere currently (other than by me manually) because we do not have parse tests
3. Automatically generates `forall<T> { IsLocal(Foo<T>) }` for `struct Foo<T: Eq>` and generates nothing extra for `extern struct Bar<T: Eq>` because it is marked `extern`
