### PR TITLE
Added #[fundamental] for structs

### DIFF
--- a/chalk-parse/src/ast.rs
+++ b/chalk-parse/src/ast.rs
@@ -34,6 +34,7 @@ pub struct StructDefn {
 
 pub struct StructFlags {
     pub external: bool,
+    pub fundamental: bool,
 }
 
 pub struct TraitDefn {

--- a/chalk-parse/src/parser.lalrpop
+++ b/chalk-parse/src/parser.lalrpop
@@ -39,9 +39,10 @@ ExternalKeyword: () = "extern";
 AutoKeyword: () = "#" "[" "auto" "]";
 MarkerKeyword: () = "#" "[" "marker" "]";
 DerefLangItem: () = "#" "[" "lang_deref" "]";
+FundamentalKeyword: () = "#" "[" "fundamental" "]";
 
 StructDefn: StructDefn = {
-    <external:ExternalKeyword?> "struct" <n:Id><p:Angle<ParameterKind>>
+    <fundamental:FundamentalKeyword?> <external:ExternalKeyword?> "struct" <n:Id><p:Angle<ParameterKind>>
         <w:QuantifiedWhereClauses> "{" <f:Fields> "}" => StructDefn
     {
         name: n,
@@ -50,6 +51,7 @@ StructDefn: StructDefn = {
         fields: f,
         flags: StructFlags {
             external: external.is_some(),
+            fundamental: fundamental.is_some(),
         },
     }
 };

--- a/libstd.chalk
+++ b/libstd.chalk
@@ -24,6 +24,7 @@ struct Rc<T> { }
 impl<T> Clone for Rc<T> { }
 impl<T> Sized for Rc<T> { }
 
+#[fundamental]
 struct Box<T> { }
 impl<T> AsRef<T> for Box<T> where T: Sized { }
 impl<T> Clone for Box<T> where T: Clone { }
@@ -39,4 +40,3 @@ impl<T> AsRef<Slice<T>> for Vec<T> where T: Sized { }
 impl<T> AsRef<Vec<T>> for Vec<T> where T: Sized { }
 impl<T> Clone for Vec<T> where T: Clone, T: Sized { }
 impl<T> Sized for Vec<T> where T: Sized { }
-

--- a/src/ir.rs
+++ b/src/ir.rs
@@ -349,6 +349,10 @@ impl ApplicationTy {
         // This unwrap() is safe because is_ty ensures that we definitely have a Ty
         self.parameters.iter().find(|p| p.is_ty()).map(|p| p.clone().ty().unwrap())
     }
+
+    crate fn len_type_parameters(&self) -> usize {
+        self.parameters.iter().filter(|p| p.is_ty()).count()
+    }
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
@@ -703,10 +707,6 @@ impl<T> Binders<T> {
 
     crate fn len(&self) -> usize {
         self.binders.len()
-    }
-
-    crate fn len_type_parameters(&self) -> usize {
-        self.binders.iter().filter(|p| p.is_ty()).count()
     }
 }
 

--- a/src/ir.rs
+++ b/src/ir.rs
@@ -236,6 +236,7 @@ pub struct StructDatumBound {
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct StructFlags {
     crate external: bool,
+    crate fundamental: bool,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]

--- a/src/ir.rs
+++ b/src/ir.rs
@@ -344,6 +344,13 @@ pub struct ApplicationTy {
     crate parameters: Vec<Parameter>,
 }
 
+impl ApplicationTy {
+    crate fn first_type_parameter(&self) -> Option<Ty> {
+        // This unwrap() is safe because is_ty ensures that we definitely have a Ty
+        self.parameters.iter().find(|p| p.is_ty()).map(|p| p.clone().ty().unwrap())
+    }
+}
+
 #[derive(Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum ParameterKind<T, L = T> {
     Ty(T),
@@ -382,6 +389,13 @@ impl<T, L> ParameterKind<T, L> {
         match *self {
             ParameterKind::Ty(ref t) => ParameterKind::Ty(t),
             ParameterKind::Lifetime(ref l) => ParameterKind::Lifetime(l),
+        }
+    }
+
+    crate fn is_ty(&self) -> bool {
+        match self {
+            ParameterKind::Ty(_) => true,
+            ParameterKind::Lifetime(_) => false,
         }
     }
 
@@ -689,6 +703,10 @@ impl<T> Binders<T> {
 
     crate fn len(&self) -> usize {
         self.binders.len()
+    }
+
+    crate fn len_type_parameters(&self) -> usize {
+        self.binders.iter().filter(|p| p.is_ty()).count()
     }
 }
 

--- a/src/ir/lowering.rs
+++ b/src/ir/lowering.rs
@@ -575,6 +575,7 @@ impl LowerStructDefn for StructDefn {
                 where_clauses,
                 flags: ir::StructFlags {
                     external: self.flags.external,
+                    fundamental: self.flags.fundamental,
                 },
             })
         })?;

--- a/src/ir/lowering.rs
+++ b/src/ir/lowering.rs
@@ -566,6 +566,10 @@ impl LowerStructDefn for StructDefn {
                     .collect(),
             };
 
+            if self.flags.fundamental && self_ty.len_type_parameters() != 1 {
+                bail!("Only fundamental types with a single parameter are supported");
+            }
+
             let fields: Result<_> = self.fields.iter().map(|f| f.ty.lower(env)).collect();
             let where_clauses = self.lower_where_clauses(env)?;
 

--- a/src/ir/lowering/test.rs
+++ b/src/ir/lowering/test.rs
@@ -370,3 +370,17 @@ fn duplicate_parameters() {
         }
     }
 }
+
+#[test]
+fn fundamental_multiple_type_parameters() {
+    lowering_error! {
+        program {
+            #[fundamental]
+            struct Boxes<T, U> { }
+        }
+
+        error_msg {
+            "Only fundamental types with a single parameter are supported"
+        }
+    }
+}

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -320,7 +320,7 @@ impl ir::StructDatum {
             // one type parameter, nor do we know what the behaviour for that should be. Thus, we
             // are asserting here that there is only a single type parameter until the day when
             // someone makes a decision about how that should behave.
-            assert_eq!(self.binders.len_type_parameters(), 1,
+            assert_eq!(self.binders.value.self_ty.len_type_parameters(), 1,
                 "Only fundamental types with a single parameter are supported");
 
             let local_fundamental = self.binders.map_ref(|bound_datum| ir::ProgramClauseImplication {

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -276,6 +276,15 @@ impl ir::StructDatum {
         // If the type Foo is not marked `extern`, we also generate:
         //
         //    forall<T> { IsLocalTy(Foo<T>) }
+        //
+        // Given an `extern` type that is also fundamental:
+        //
+        //    #[fundamental]
+        //    extern struct Box<T> {}
+        //
+        // We generate the following clause:
+        //
+        //    forall<T> { IsLocalTy(Box<T>) :- IsLocalTy(T) }
 
         let wf = self.binders.map_ref(|bound_datum| {
             ir::ProgramClauseImplication {
@@ -302,6 +311,30 @@ impl ir::StructDatum {
             }).cast();
 
             clauses.push(is_local);
+        }
+        // If a type is `extern`, but is also `#[fundamental]`, it satisfies IsLocalTy
+        // if and only if its parameters satisfy IsLocalTy
+        else if self.binders.value.flags.fundamental {
+            // Fundamental types must always have at least one type parameter for this rule to
+            // make any sense. We currently do not have have any fundamental types with more than
+            // one type parameter, nor do we know what the behaviour for that should be. Thus, we
+            // are asserting here that there is only a single type parameter until the day when
+            // someone makes a decision about how that should behave.
+            assert_eq!(self.binders.len_type_parameters(), 1,
+                "Only fundamental types with a single parameter are supported");
+
+            let local_fundamental = self.binders.map_ref(|bound_datum| ir::ProgramClauseImplication {
+                consequence: ir::DomainGoal::IsLocalTy(bound_datum.self_ty.clone().cast()),
+                conditions: vec![
+                    ir::DomainGoal::IsLocalTy(
+                        // This unwrap is safe because we asserted above for the presence of a type
+                        // parameter
+                        bound_datum.self_ty.first_type_parameter().unwrap()
+                    ).cast(),
+                ],
+            }).cast();
+
+            clauses.push(local_fundamental);
         }
 
         let condition = ir::DomainGoal::FromEnvTy(self.binders.value.self_ty.clone().cast());

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -311,10 +311,10 @@ impl ir::StructDatum {
             }).cast();
 
             clauses.push(is_local);
-        }
-        // If a type is `extern`, but is also `#[fundamental]`, it satisfies IsLocalTy
-        // if and only if its parameters satisfy IsLocalTy
-        else if self.binders.value.flags.fundamental {
+        } else if self.binders.value.flags.fundamental {
+            // If a type is `extern`, but is also `#[fundamental]`, it satisfies IsLocalTy
+            // if and only if its parameters satisfy IsLocalTy
+
             // Fundamental types must always have at least one type parameter for this rule to
             // make any sense. We currently do not have have any fundamental types with more than
             // one type parameter, nor do we know what the behaviour for that should be. Thus, we

--- a/src/solve/test.rs
+++ b/src/solve/test.rs
@@ -2140,6 +2140,7 @@ fn fundamental_types() {
 
         // Without fundamental, Box should never be local
         goal { forall<T> { not { IsLocal(Box<T>) } } } yields { "Unique" }
+        goal { forall<T> { IsLocal(Box<T>) } } yields { "No possible solution" }
 
         // Without fundamental, both of these are always non-local
         goal { IsLocal(Box<External>) } yields { "No possible solution" }
@@ -2157,6 +2158,7 @@ fn fundamental_types() {
 
         // With fundamental, Box can be local for certain types
         goal { forall<T> { not { IsLocal(Box<T>) } } } yields { "No possible solution" }
+        goal { forall<T> { IsLocal(Box<T>) } } yields { "No possible solution" }
 
         // With fundamental, each of these yields different results
         goal { IsLocal(Box<External>) } yields { "No possible solution" }


### PR DESCRIPTION
This adds the ability to have `#[fundamental]` on structs in chalk. I recommend looking at the test that I added for complete examples of the behaviour that this enables. Some parts of that test are a bit redundant because of how `forall` works, but I did it like that so I could check every case and so that we know that each of the cases I covered work as we would expect them to.

Usually, if you have a type `extern struct External<T>`, you want `IsLocal(External<T>)` to be false regardless of the type of `T`. There are certain "fundamental" types however which benefit from a slightly modified rule. Take `Box<T>` for example. Given a crate that defines `MyInternalType`, we want that crate to be able to implement traits on `Box<MyInternalType>`. To allow this, we make `Box<T>` a "fundamental" type with the `#[fundamental]` attribute. This makes it so that `IsLocal(Box<T>)` can be true if and only if `IsLocal(T)` is true. For the crate mentioned previously, `IsLocal(MyInternalType)` would be true and that would allow them to define a trait for `Box<MyInternalType>` because `IsLocal(Box<MyInternalType>)` would also become true thanks to `Box<T>` being fundamental.

`#[fundamental]` **only** changes the behaviour of types that are marked `extern`. If a type is not marked `extern`, then it should always satisfy `IsLocal` regardless of anything else. An example where this comes up is for `Box<T>` when we are compiling `std`. This allows us to implement any trait for any `Box<T>` regardless of whether `T` is local or extern. This is okay because in the context of compiling `std`, `Box<T>` is local. This is the same behaviour you would expect with any non-fundamental type too.