### PR TITLE
Rename IsLocal to ImplAllowed

### DIFF
--- a/chalk-parse/src/ast.rs
+++ b/chalk-parse/src/ast.rs
@@ -218,7 +218,7 @@ pub enum WhereClause {
     UnifyLifetimes { a: Lifetime, b: Lifetime },
     TraitInScope { trait_name: Identifier },
     Derefs { source: Ty, target: Ty },
-    TyIsLocal { ty: Ty },
+    IsLocal { ty: Ty },
 }
 
 pub struct QuantifiedWhereClause {

--- a/chalk-parse/src/parser.lalrpop
+++ b/chalk-parse/src/parser.lalrpop
@@ -273,7 +273,7 @@ WhereClause: WhereClause = {
     "InScope" "(" <t:Id> ")" => WhereClause::TraitInScope { trait_name: t },
     "Derefs" "(" <source:Ty> "," <target:Ty> ")" => WhereClause::Derefs { source, target },
 
-    "IsLocal" "(" <ty:Ty> ")" => WhereClause::TyIsLocal { ty },
+    "IsLocal" "(" <ty:Ty> ")" => WhereClause::IsLocal { ty },
 };
 
 QuantifiedWhereClause: QuantifiedWhereClause = {

--- a/src/fold.rs
+++ b/src/fold.rs
@@ -425,7 +425,7 @@ enum_fold!(PolarizedTraitRef[] { Positive(a), Negative(a) });
 enum_fold!(ParameterKind[T,L] { Ty(a), Lifetime(a) } where T: Fold, L: Fold);
 enum_fold!(WhereClauseAtom[] { Implemented(a), ProjectionEq(a) });
 enum_fold!(DomainGoal[] { Holds(a), WellFormed(a), FromEnv(a), Normalize(a), UnselectedNormalize(a),
-                          WellFormedTy(a), FromEnvTy(a), InScope(a), Derefs(a), IsLocalTy(a), IsLocalTraitRef(a) });
+                          WellFormedTy(a), FromEnvTy(a), InScope(a), Derefs(a), IsLocal(a), LocalImplAllowed(a) });
 enum_fold!(LeafGoal[] { EqGoal(a), DomainGoal(a) });
 enum_fold!(Constraint[] { LifetimeEq(a, b) });
 enum_fold!(Goal[] { Quantified(qkind, subgoal), Implies(wc, subgoal), And(g1, g2), Not(g),

--- a/src/ir.rs
+++ b/src/ir.rs
@@ -269,7 +269,7 @@ pub enum InlineBound {
 
 impl InlineBound {
     /// Applies the `InlineBound` to `self_ty` and lowers to a [`DomainGoal`].
-    /// 
+    ///
     /// Because an `InlineBound` does not know anything about what it's binding,
     /// you must provide that type as `self_ty`.
     crate fn lower_with_self(&self, self_ty: Ty) -> Vec<DomainGoal> {
@@ -691,8 +691,16 @@ pub enum DomainGoal {
     /// True if a type is considered to have been "defined" by the current crate. This is true for
     /// a `struct Foo { }` but false for a `extern struct Foo { }`. However, for fundamental types
     /// like `Box<T>`, it is true if `T` is local.
-    IsLocalTy(Ty),
-    IsLocalTraitRef(TraitRef),
+    IsLocal(Ty),
+
+    /// Used to dictate when trait impls are allowed in the current (local) crate based on the
+    /// orphan rules.
+    ///
+    /// `LocalImplAllowed(T: Trait)` is true if the type T is allowed to impl trait Trait in
+    /// the current crate. Under the current rules, this is unconditionally true for all types if
+    /// the Trait is considered to be "defined" in the current crate. If that is not the case, then
+    /// `LocalImplAllowed(T: Trait)` can still be true if `IsLocal(T)` is true.
+    LocalImplAllowed(TraitRef),
 }
 
 pub type QuantifiedDomainGoal = Binders<DomainGoal>;

--- a/src/ir/debug.rs
+++ b/src/ir/debug.rs
@@ -206,8 +206,8 @@ impl Debug for DomainGoal {
             DomainGoal::FromEnvTy(t) => write!(fmt, "FromEnv({:?})", t),
             DomainGoal::InScope(n) => write!(fmt, "InScope({:?})", n),
             DomainGoal::Derefs(n) => write!(fmt, "Derefs({:?})", n),
-            DomainGoal::IsLocalTy(n) => write!(fmt, "IsLocalTy({:?})", n),
-            DomainGoal::IsLocalTraitRef(n) => write!(fmt, "IsLocalTraitRef({:?})", n),
+            DomainGoal::IsLocal(n) => write!(fmt, "IsLocal({:?})", n),
+            DomainGoal::LocalImplAllowed(n) => write!(fmt, "LocalImplAllowed({:?})", n),
         }
     }
 }

--- a/src/ir/lowering.rs
+++ b/src/ir/lowering.rs
@@ -494,8 +494,8 @@ impl LowerWhereClause<ir::DomainGoal> for WhereClause {
                     target: target.lower(env)?
                 })
             ],
-            WhereClause::TyIsLocal { ty } => vec![
-                ir::DomainGoal::IsLocalTy(ty.lower(env)?)
+            WhereClause::IsLocal { ty } => vec![
+                ir::DomainGoal::IsLocal(ty.lower(env)?)
             ],
         };
         Ok(goals)
@@ -527,7 +527,7 @@ impl LowerWhereClause<ir::LeafGoal> for WhereClause {
             | WhereClause::TyFromEnv { .. }
             | WhereClause::TraitRefFromEnv { .. }
             | WhereClause::Derefs { .. }
-            | WhereClause::TyIsLocal { .. } => {
+            | WhereClause::IsLocal { .. } => {
                 let goals: Vec<ir::DomainGoal> = self.lower(env)?;
                 goals.into_iter().casted().collect()
             }

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -294,7 +294,7 @@ impl ir::StructDatum {
         //
         // If the type Foo is not marked `extern`, we also generate:
         //
-        //    forall<T> { IsLocalTy(Foo<T>) }
+        //    forall<T> { IsLocal(Foo<T>) }
         //
         // Given an `extern` type that is also fundamental:
         //
@@ -303,7 +303,7 @@ impl ir::StructDatum {
         //
         // We generate the following clause:
         //
-        //    forall<T> { IsLocalTy(Box<T>) :- IsLocalTy(T) }
+        //    forall<T> { IsLocal(Box<T>) :- IsLocal(T) }
 
         let wf = self.binders.map_ref(|bound_datum| {
             ir::ProgramClauseImplication {
@@ -323,16 +323,16 @@ impl ir::StructDatum {
 
         // Types that are not marked `extern` satisfy IsLocal(TypeName)
         if !self.binders.value.flags.external {
-            // `IsLocalTy(Ty)` depends *only* on whether the type is marked extern and nothing else
+            // `IsLocal(Ty)` depends *only* on whether the type is marked extern and nothing else
             let is_local = self.binders.map_ref(|bound_datum| ir::ProgramClauseImplication {
-                consequence: ir::DomainGoal::IsLocalTy(bound_datum.self_ty.clone().cast()),
+                consequence: ir::DomainGoal::IsLocal(bound_datum.self_ty.clone().cast()),
                 conditions: Vec::new(),
             }).cast();
 
             clauses.push(is_local);
         } else if self.binders.value.flags.fundamental {
-            // If a type is `extern`, but is also `#[fundamental]`, it satisfies IsLocalTy
-            // if and only if its parameters satisfy IsLocalTy
+            // If a type is `extern`, but is also `#[fundamental]`, it satisfies IsLocal
+            // if and only if its parameters satisfy IsLocal
 
             // Fundamental types must always have at least one type parameter for this rule to
             // make any sense. We currently do not have have any fundamental types with more than
@@ -343,9 +343,9 @@ impl ir::StructDatum {
                 "Only fundamental types with a single parameter are supported");
 
             let local_fundamental = self.binders.map_ref(|bound_datum| ir::ProgramClauseImplication {
-                consequence: ir::DomainGoal::IsLocalTy(bound_datum.self_ty.clone().cast()),
+                consequence: ir::DomainGoal::IsLocal(bound_datum.self_ty.clone().cast()),
                 conditions: vec![
-                    ir::DomainGoal::IsLocalTy(
+                    ir::DomainGoal::IsLocal(
                         // This unwrap is safe because we asserted above for the presence of a type
                         // parameter
                         bound_datum.self_ty.first_type_parameter().unwrap()

--- a/src/rules/wf.rs
+++ b/src/rules/wf.rs
@@ -143,8 +143,8 @@ impl FoldInputTypes for DomainGoal {
             DomainGoal::FromEnv(..) |
             DomainGoal::WellFormedTy(..) |
             DomainGoal::FromEnvTy(..) |
-            DomainGoal::IsLocalTy(..) |
-            DomainGoal::IsLocalTraitRef(..) |
+            DomainGoal::IsLocal(..) |
+            DomainGoal::LocalImplAllowed(..) |
             DomainGoal::Derefs(..) => panic!("unexpected where clause"),
 
             DomainGoal::InScope(..) => (),

--- a/src/zip.rs
+++ b/src/zip.rs
@@ -227,8 +227,8 @@ enum_zip!(DomainGoal {
     FromEnvTy,
     InScope,
     Derefs,
-    IsLocalTy,
-    IsLocalTraitRef
+    IsLocal,
+    LocalImplAllowed
 });
 enum_zip!(LeafGoal { DomainGoal, EqGoal });
 enum_zip!(ProgramClause { Implies, ForAll });


### PR DESCRIPTION
After some discussion on Discord, it became clear that the name `IsLocal` is a little confusing and misleading. The interpretation that @nikomatsakis intended for `IsLocal(T: Trait)` was that a "trait ref being local" basically says "this crate is allowed to write that impl" under the orphan rules. This is different (but related) to the description we had before in the documentation for `IsLocal`:

> True if a type is considered to have been "defined" by the current crate.

If all we're looking at is whether a type or trait is "defined" in the current crate, then having `IsLocal(T: Trait)` doesn't really make sense. You would probably want something like `IsLocal(Trait)` instead.

The goal of this work is to model the orphan rules in chalk as part of coherence. That means that the information we're really looking for is actually whether implementing traits for a given type is allowed based on those rules.

Instead of `IsLocal(T)` and `IsLocal(T: Trait)`, this PR renames that domain goal to be `ImplAllowed(T)` and `ImplAllowed(T: Trait)` to signify when the current crate is allowed to implement traits for a type.

* We use `ImplAllowed(T)` for each non-extern type `T` to signify that implementing any trait is fine for that type.
* We use `forall<T> { ImplAllowed(T: Trait) }` when a trait is local to signify that implementing that trait for any type is fine under the orphan rules. If a trait is extern, we have a slightly different rule that says `forall<T> { ImplAllowed(T: Trait) :- ImplAllowed(T) }` to allow you to implement external traits for your internal types.

I think this new name will help clear up a lot and generally make this concept easier to understand.

*Note:* The `IsLocal(T: Trait)` syntax and rules are **not** implemented yet but you should expect a follow-up PR very soon to add that. 