### PR TITLE
Implementing LocalImplAllowed(T: Trait) for local and external traits

### DIFF
--- a/chalk-parse/src/ast.rs
+++ b/chalk-parse/src/ast.rs
@@ -243,6 +243,7 @@ pub enum DomainGoal {
     TraitInScope { trait_name: Identifier },
     Derefs { source: Ty, target: Ty },
     IsLocal { ty: Ty },
+    LocalImplAllowed { trait_ref: TraitRef },
 }
 
 #[derive(Clone, PartialEq, Eq, Debug)]

--- a/chalk-parse/src/parser.lalrpop
+++ b/chalk-parse/src/parser.lalrpop
@@ -287,6 +287,8 @@ DomainGoal: DomainGoal = {
     "Derefs" "(" <source:Ty> "," <target:Ty> ")" => DomainGoal::Derefs { source, target },
 
     "IsLocal" "(" <ty:Ty> ")" => DomainGoal::IsLocal { ty },
+
+    "LocalImplAllowed" "(" <trait_ref:TraitRef<":">> ")" => DomainGoal::LocalImplAllowed { trait_ref },
 };
 
 LeafGoal: LeafGoal = {

--- a/src/ir/debug.rs
+++ b/src/ir/debug.rs
@@ -213,7 +213,13 @@ impl Debug for DomainGoal {
             DomainGoal::InScope(n) => write!(fmt, "InScope({:?})", n),
             DomainGoal::Derefs(n) => write!(fmt, "Derefs({:?})", n),
             DomainGoal::IsLocal(n) => write!(fmt, "IsLocal({:?})", n),
-            DomainGoal::LocalImplAllowed(n) => write!(fmt, "LocalImplAllowed({:?})", n),
+            DomainGoal::LocalImplAllowed(tr) => write!(
+                fmt,
+                "LocalImplAllowed({:?}: {:?}{:?})",
+                tr.parameters[0],
+                tr.trait_id,
+                Angle(&tr.parameters[1..])
+            ),
         }
     }
 }

--- a/src/ir/lowering.rs
+++ b/src/ir/lowering.rs
@@ -524,6 +524,9 @@ impl LowerDomainGoal for DomainGoal {
             DomainGoal::IsLocal { ty } => vec![
                 ir::DomainGoal::IsLocal(ty.lower(env)?)
             ],
+            DomainGoal::LocalImplAllowed { trait_ref } => vec![
+                ir::DomainGoal::LocalImplAllowed(trait_ref.lower(env)?)
+            ],
         };
         Ok(goals)
     }

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -452,17 +452,23 @@ impl TraitDatum {
         let mut clauses = vec![wf];
 
         if !self.binders.value.flags.external {
-            let impl_allowed = self.binders.map_ref(|bound_datum| ProgramClauseImplication {
-                consequence: DomainGoal::LocalImplAllowed(bound_datum.self_ty.clone().cast()),
-                conditions: Vec::new(),
-            }).cast();
+            let impl_allowed = self.binders.map_ref(|bound_datum|
+                ProgramClauseImplication {
+                    consequence: DomainGoal::LocalImplAllowed(bound_datum.trait_ref.clone()),
+                    conditions: Vec::new(),
+                }
+            ).cast();
 
             clauses.push(impl_allowed);
         } else {
-            let impl_maybe_allowed = self.binders.map_ref(|bound_datum| ProgramClauseImplication {
-                consequence: DomainGoal::LocalImplAllowed(bound_datum.self_ty.clone().cast()),
-                conditions: Vec::new(),
-            }).cast();
+            let impl_maybe_allowed = self.binders.map_ref(|bound_datum|
+                ProgramClauseImplication {
+                    consequence: DomainGoal::LocalImplAllowed(bound_datum.trait_ref.clone()),
+                    conditions: vec![
+                        DomainGoal::IsLocal(bound_datum.trait_ref.parameters[0].assert_ty_ref().clone()).cast(),
+                    ],
+                }
+            ).cast();
 
             clauses.push(impl_maybe_allowed);
         }

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -158,7 +158,7 @@ impl AssociatedTyValue {
     ///     type IntoIter<'a>: 'a;
     /// }
     /// ```
-    /// 
+    ///
     /// Then for the following impl:
     /// ```notrust
     /// impl<T> Iterable for Vec<T> {
@@ -413,6 +413,19 @@ impl TraitDatum {
         //
         //    forall<Self, T> { (Self: Ord<T>) :- FromEnv(Self: Ord<T>) }
         //    forall<Self, T> { FromEnv(Self: Eq<T>) :- FromEnv(Self: Ord<T>) }
+        //
+        // As specified in the orphan rules, if a trait is not marked `extern`, the current crate
+        // can implement it for any type. To represent that, we generate:
+        //
+        //    // `Ord<T>` would not be `extern` when compiling `std`
+        //    forall<Self, T> { LocalImplAllowed(Self: Ord<T>) }
+        //
+        // For traits that are `extern` (i.e. not in the current crate), the orphan rules specify
+        // that impls are allowed as long as the the type being implemented for is defined in the
+        // current crate. This is represented as follows:
+        //
+        //    // for `extern trait Ord<T> where Self: Eq<T> { ... }`
+        //    forall<Self, T> { LocalImplAllowed(Self: Ord<T>) :- IsLocal(Self) }
 
         let trait_ref = self.binders.value.trait_ref.clone();
 
@@ -437,6 +450,23 @@ impl TraitDatum {
         }).cast();
 
         let mut clauses = vec![wf];
+
+        if !self.binders.value.flags.external {
+            let impl_allowed = self.binders.map_ref(|bound_datum| ProgramClauseImplication {
+                consequence: DomainGoal::LocalImplAllowed(bound_datum.self_ty.clone().cast()),
+                conditions: Vec::new(),
+            }).cast();
+
+            clauses.push(impl_allowed);
+        } else {
+            let impl_maybe_allowed = self.binders.map_ref(|bound_datum| ProgramClauseImplication {
+                consequence: DomainGoal::LocalImplAllowed(bound_datum.self_ty.clone().cast()),
+                conditions: Vec::new(),
+            }).cast();
+
+            clauses.push(impl_maybe_allowed);
+        }
+
         let condition = DomainGoal::FromEnv(FromEnv::Trait(trait_ref.clone()));
 
         for wc in self.binders

--- a/src/solve/test.rs
+++ b/src/solve/test.rs
@@ -2614,3 +2614,35 @@ fn fundamental_types() {
         goal { IsLocal(Box<Internal>) } yields { "Unique" }
     }
 }
+
+#[test]
+fn impl_allowed_for_traits() {
+    test! {
+        program {
+            extern trait ExternalTrait { }
+            trait InternalTrait { }
+
+            extern struct External { }
+            struct Internal { }
+        }
+
+        goal { forall<T> { LocalImplAllowed(T: ExternalTrait) } } yields { "No possible solution" }
+
+        goal { forall<T> { LocalImplAllowed(T: InternalTrait) } } yields { "Unique" }
+    }
+
+    test! {
+        program {
+            trait Clone { }
+            extern trait ExternalTrait<T> where T: Clone { }
+            trait InternalTrait<T> where T: Clone { }
+
+            extern struct External { }
+            struct Internal { }
+        }
+
+        goal { forall<T, U> { LocalImplAllowed(T: ExternalTrait<U>) } } yields { "No possible solution" }
+
+        goal { forall<T, U> { LocalImplAllowed(T: InternalTrait<U>) } } yields { "Unique" }
+    }
+}

--- a/src/solve/test.rs
+++ b/src/solve/test.rs
@@ -2627,8 +2627,12 @@ fn impl_allowed_for_traits() {
         }
 
         goal { forall<T> { LocalImplAllowed(T: ExternalTrait) } } yields { "No possible solution" }
+        goal { LocalImplAllowed(Internal: ExternalTrait) } yields { "Unique" }
+        goal { LocalImplAllowed(External: ExternalTrait) } yields { "No possible solution" }
 
         goal { forall<T> { LocalImplAllowed(T: InternalTrait) } } yields { "Unique" }
+        goal { LocalImplAllowed(Internal: InternalTrait) } yields { "Unique" }
+        goal { LocalImplAllowed(External: InternalTrait) } yields { "Unique" }
     }
 
     test! {
@@ -2642,7 +2646,11 @@ fn impl_allowed_for_traits() {
         }
 
         goal { forall<T, U> { LocalImplAllowed(T: ExternalTrait<U>) } } yields { "No possible solution" }
+        goal { forall<T> { LocalImplAllowed(Internal: ExternalTrait<T>) } } yields { "Unique" }
+        goal { forall<T> { LocalImplAllowed(External: ExternalTrait<T>) } } yields { "No possible solution" }
 
         goal { forall<T, U> { LocalImplAllowed(T: InternalTrait<U>) } } yields { "Unique" }
+        goal { forall<T> { LocalImplAllowed(Internal: InternalTrait<T>) } } yields { "Unique" }
+        goal { forall<T> { LocalImplAllowed(External: InternalTrait<T>) } } yields { "Unique" }
     }
 }


### PR DESCRIPTION
This currently contains a bunch of the changes from #140. Once that is merged, the extra changes should disappear automatically. Even with those extra changes, this isn't too difficult to review.

This PR automatically adds the appropriate program clauses for local and external traits. Those program clauses use a new domain goal `LocalImplAllowed(T: Trait)`. That domain goal will be used to implement the coherence + orphan rules.