### PR TITLE
Refactor `WhereClauseAtom` into `WhereClause`.

### DIFF
--- a/chalk-parse/src/ast.rs
+++ b/chalk-parse/src/ast.rs
@@ -1,7 +1,7 @@
 use lalrpop_intern::InternedString;
 use std::fmt;
 
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
 pub struct Span {
     pub lo: usize,
     pub hi: usize,
@@ -13,10 +13,12 @@ impl Span {
     }
 }
 
+#[derive(Clone, PartialEq, Eq, Debug)]
 pub struct Program {
     pub items: Vec<Item>
 }
 
+#[derive(Clone, PartialEq, Eq, Debug)]
 pub enum Item {
     StructDefn(StructDefn),
     TraitDefn(TraitDefn),
@@ -24,6 +26,7 @@ pub enum Item {
     Clause(Clause),
 }
 
+#[derive(Clone, PartialEq, Eq, Debug)]
 pub struct StructDefn {
     pub name: Identifier,
     pub parameter_kinds: Vec<ParameterKind>,
@@ -32,11 +35,13 @@ pub struct StructDefn {
     pub flags: StructFlags,
 }
 
+#[derive(Clone, PartialEq, Eq, Debug)]
 pub struct StructFlags {
     pub external: bool,
     pub fundamental: bool,
 }
 
+#[derive(Clone, PartialEq, Eq, Debug)]
 pub struct TraitDefn {
     pub name: Identifier,
     pub parameter_kinds: Vec<ParameterKind>,
@@ -45,6 +50,7 @@ pub struct TraitDefn {
     pub flags: TraitFlags,
 }
 
+#[derive(Clone, PartialEq, Eq, Debug)]
 pub struct TraitFlags {
     pub auto: bool,
     pub marker: bool,
@@ -52,6 +58,7 @@ pub struct TraitFlags {
     pub deref: bool,
 }
 
+#[derive(Clone, PartialEq, Eq, Debug)]
 pub struct AssocTyDefn {
     pub name: Identifier,
     pub parameter_kinds: Vec<ParameterKind>,
@@ -59,22 +66,26 @@ pub struct AssocTyDefn {
     pub where_clauses: Vec<QuantifiedWhereClause>,
 }
 
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
 pub enum ParameterKind {
     Ty(Identifier),
     Lifetime(Identifier),
 }
 
+#[derive(Clone, PartialEq, Eq, Debug)]
 pub enum Parameter {
     Ty(Ty),
     Lifetime(Lifetime),
 }
 
+#[derive(Clone, PartialEq, Eq, Debug)]
 /// An inline bound, e.g. `: Foo<K>` in `impl<K, T: Foo<K>> SomeType<T>`.
 pub enum InlineBound {
     TraitBound(TraitBound),
     ProjectionEqBound(ProjectionEqBound),
 }
 
+#[derive(Clone, PartialEq, Eq, Debug)]
 /// Represents a trait bound on e.g. a type or type parameter.
 /// Does not know anything about what it's binding.
 pub struct TraitBound {
@@ -82,6 +93,7 @@ pub struct TraitBound {
     pub args_no_self: Vec<Parameter>,
 }
 
+#[derive(Clone, PartialEq, Eq, Debug)]
 /// Represents a projection equality bound on e.g. a type or type parameter.
 /// Does not know anything about what it's binding.
 pub struct ProjectionEqBound {
@@ -91,7 +103,7 @@ pub struct ProjectionEqBound {
     pub value: Ty,
 }
 
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
 pub enum Kind {
     Ty,
     Lifetime,
@@ -130,6 +142,7 @@ impl Kinded for Parameter {
     }
 }
 
+#[derive(Clone, PartialEq, Eq, Debug)]
 pub struct Impl {
     pub parameter_kinds: Vec<ParameterKind>,
     pub trait_ref: PolarizedTraitRef,
@@ -137,12 +150,14 @@ pub struct Impl {
     pub assoc_ty_values: Vec<AssocTyValue>,
 }
 
+#[derive(Clone, PartialEq, Eq, Debug)]
 pub struct AssocTyValue {
     pub name: Identifier,
     pub parameter_kinds: Vec<ParameterKind>,
     pub value: Ty,
 }
 
+#[derive(Clone, PartialEq, Eq, Debug)]
 pub enum Ty {
     Id {
         name: Identifier,
@@ -163,28 +178,33 @@ pub enum Ty {
     }
 }
 
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
 pub enum Lifetime {
     Id {
         name: Identifier,
     }
 }
 
+#[derive(Clone, PartialEq, Eq, Debug)]
 pub struct ProjectionTy {
     pub trait_ref: TraitRef,
     pub name: Identifier,
     pub args: Vec<Parameter>,
 }
 
+#[derive(Clone, PartialEq, Eq, Debug)]
 pub struct UnselectedProjectionTy {
     pub name: Identifier,
     pub args: Vec<Parameter>,
 }
 
+#[derive(Clone, PartialEq, Eq, Debug)]
 pub struct TraitRef {
     pub trait_name: Identifier,
     pub args: Vec<Parameter>,
 }
 
+#[derive(Clone, PartialEq, Eq, Debug)]
 pub enum PolarizedTraitRef {
     Positive(TraitRef),
     Negative(TraitRef),
@@ -200,17 +220,19 @@ impl PolarizedTraitRef {
     }
 }
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
 pub struct Identifier {
     pub str: InternedString,
     pub span: Span,
 }
 
+#[derive(Clone, PartialEq, Eq, Debug)]
 pub enum WhereClause {
     Implemented { trait_ref: TraitRef },
     ProjectionEq { projection: ProjectionTy, ty: Ty },
 }
 
+#[derive(Clone, PartialEq, Eq, Debug)]
 pub enum DomainGoal {
     Holds { where_clause: WhereClause },
     Normalize { projection: ProjectionTy, ty: Ty },
@@ -223,22 +245,26 @@ pub enum DomainGoal {
     IsLocal { ty: Ty },
 }
 
+#[derive(Clone, PartialEq, Eq, Debug)]
 pub enum LeafGoal {
     DomainGoal { goal: DomainGoal },
     UnifyTys { a: Ty, b: Ty },
     UnifyLifetimes { a: Lifetime, b: Lifetime },
 }
 
+#[derive(Clone, PartialEq, Eq, Debug)]
 pub struct QuantifiedWhereClause {
     pub parameter_kinds: Vec<ParameterKind>,
     pub where_clause: WhereClause,
 }
 
+#[derive(Clone, PartialEq, Eq, Debug)]
 pub struct Field {
     pub name: Identifier,
     pub ty: Ty,
 }
 
+#[derive(Clone, PartialEq, Eq, Debug)]
 /// This allows users to add arbitrary `A :- B` clauses into the
 /// logic; it has no equivalent in Rust, but it's useful for testing.
 pub struct Clause {
@@ -247,6 +273,7 @@ pub struct Clause {
     pub conditions: Vec<Box<Goal>>,
 }
 
+#[derive(Clone, PartialEq, Eq, Debug)]
 pub enum Goal {
     ForAll(Vec<ParameterKind>, Box<Goal>),
     Exists(Vec<ParameterKind>, Box<Goal>),

--- a/chalk-parse/src/ast.rs
+++ b/chalk-parse/src/ast.rs
@@ -208,17 +208,25 @@ pub struct Identifier {
 
 pub enum WhereClause {
     Implemented { trait_ref: TraitRef },
-    Normalize { projection: ProjectionTy, ty: Ty },
     ProjectionEq { projection: ProjectionTy, ty: Ty },
-    TyWellFormed { ty: Ty },
+}
+
+pub enum DomainGoal {
+    Holds { where_clause: WhereClause },
+    Normalize { projection: ProjectionTy, ty: Ty },
     TraitRefWellFormed { trait_ref: TraitRef },
+    TyWellFormed { ty: Ty },
     TyFromEnv { ty: Ty },
     TraitRefFromEnv { trait_ref: TraitRef },
-    UnifyTys { a: Ty, b: Ty },
-    UnifyLifetimes { a: Lifetime, b: Lifetime },
     TraitInScope { trait_name: Identifier },
     Derefs { source: Ty, target: Ty },
     IsLocal { ty: Ty },
+}
+
+pub enum LeafGoal {
+    DomainGoal { goal: DomainGoal },
+    UnifyTys { a: Ty, b: Ty },
+    UnifyLifetimes { a: Lifetime, b: Lifetime },
 }
 
 pub struct QuantifiedWhereClause {
@@ -235,7 +243,7 @@ pub struct Field {
 /// logic; it has no equivalent in Rust, but it's useful for testing.
 pub struct Clause {
     pub parameter_kinds: Vec<ParameterKind>,
-    pub consequence: WhereClause,
+    pub consequence: DomainGoal,
     pub conditions: Vec<Box<Goal>>,
 }
 
@@ -247,5 +255,5 @@ pub enum Goal {
     Not(Box<Goal>),
 
     // Additional kinds of goals:
-    Leaf(WhereClause),
+    Leaf(LeafGoal),
 }

--- a/chalk-parse/src/parser.lalrpop
+++ b/chalk-parse/src/parser.lalrpop
@@ -29,9 +29,9 @@ pub Goal: Box<Goal> = {
 Goal1: Box<Goal> = {
     "forall" "<" <p:Comma<ParameterKind>> ">" "{" <g:Goal> "}" => Box::new(Goal::ForAll(p, g)),
     "exists" "<" <p:Comma<ParameterKind>> ">" "{" <g:Goal> "}" => Box::new(Goal::Exists(p, g)),
-    "if" "(" <w:SemiColon<InlineClause>> ")" "{" <g:Goal> "}" => Box::new(Goal::Implies(w, g)),
+    "if" "(" <h:SemiColon<InlineClause>> ")" "{" <g:Goal> "}" => Box::new(Goal::Implies(h, g)),
     "not" "{" <g:Goal> "}" => Box::new(Goal::Not(g)),
-    <w:WhereClause> => Box::new(Goal::Leaf(w)),
+    <leaf:LeafGoal> => Box::new(Goal::Leaf(leaf)),
     "(" <Goal> ")",
 };
 
@@ -199,29 +199,29 @@ Field: Field = {
 };
 
 Clause: Clause = {
-    "forall" <pk:Angle<ParameterKind>> "{" <wc:WhereClause> "if" <g:Comma<Goal1>> "}" => Clause {
+    "forall" <pk:Angle<ParameterKind>> "{" <dg:DomainGoal> "if" <g:Comma<Goal1>> "}" => Clause {
         parameter_kinds: pk,
-        consequence: wc,
+        consequence: dg,
         conditions: g,
     },
 
-    "forall" <pk:Angle<ParameterKind>> "{" <wc:WhereClause> "}" => Clause {
+    "forall" <pk:Angle<ParameterKind>> "{" <dg:DomainGoal> "}" => Clause {
         parameter_kinds: pk,
-        consequence: wc,
+        consequence: dg,
         conditions: vec![],
     },
 };
 
 InlineClause1: Clause = {
-    <wc:WhereClause> => Clause {
+    <dg:DomainGoal> => Clause {
         parameter_kinds: vec![],
-        consequence: wc,
+        consequence: dg,
         conditions: vec![],
     },
 
-    <wc:WhereClause> ":" "-" <g:Comma<Goal1>> => Clause {
+    <dg:DomainGoal> ":" "-" <g:Comma<Goal1>> => Clause {
         parameter_kinds: vec![],
-        consequence: wc,
+        consequence: dg,
         conditions: g,
     },
 };
@@ -236,28 +236,8 @@ InlineClause: Clause = {
     }
 };
 
-QuantifiedWhereClauses: Vec<QuantifiedWhereClause> = {
-    "where" <Comma<QuantifiedWhereClause>>,
-    () => vec![],
-};
-
 WhereClause: WhereClause = {
     <t:TraitRef<":">> => WhereClause::Implemented { trait_ref: t },
-
-    "WellFormed" "(" <t:Ty> ")" => WhereClause::TyWellFormed { ty: t },
-
-    "WellFormed" "(" <t:TraitRef<":">> ")" => WhereClause::TraitRefWellFormed { trait_ref: t },
-
-    "FromEnv" "(" <t:Ty> ")" => WhereClause::TyFromEnv { ty: t },
-
-    "FromEnv" "(" <t:TraitRef<":">> ")" => WhereClause::TraitRefFromEnv { trait_ref: t },
-
-    <a:Ty> "=" <b:Ty> => WhereClause::UnifyTys { a, b },
-
-    <a:Lifetime> "=" <b:Lifetime> => WhereClause::UnifyLifetimes { a, b },
-
-    // `<T as Foo>::U -> Bar` -- a normalization
-    "Normalize" "(" <s:ProjectionTy> "->" <t:Ty> ")" => WhereClause::Normalize { projection: s, ty: t },
 
     // `T: Foo<U = Bar>` -- projection equality
     <s:Ty> ":" <t:Id> "<" <a:(<Comma<Parameter>> ",")?> <name:Id> <a2:Angle<Parameter>>
@@ -269,11 +249,6 @@ WhereClause: WhereClause = {
         let projection = ProjectionTy { trait_ref, name, args: a2 };
         WhereClause::ProjectionEq { projection, ty }
     },
-
-    "InScope" "(" <t:Id> ")" => WhereClause::TraitInScope { trait_name: t },
-    "Derefs" "(" <source:Ty> "," <target:Ty> ")" => WhereClause::Derefs { source, target },
-
-    "IsLocal" "(" <ty:Ty> ")" => WhereClause::IsLocal { ty },
 };
 
 QuantifiedWhereClause: QuantifiedWhereClause = {
@@ -286,6 +261,40 @@ QuantifiedWhereClause: QuantifiedWhereClause = {
         parameter_kinds: pk,
         where_clause: wc,
     },
+};
+
+QuantifiedWhereClauses: Vec<QuantifiedWhereClause> = {
+    "where" <Comma<QuantifiedWhereClause>>,
+    () => vec![],
+};
+
+DomainGoal: DomainGoal = {
+    <wc: WhereClause> => DomainGoal::Holds { where_clause: wc },
+
+    "WellFormed" "(" <t:Ty> ")" => DomainGoal::TyWellFormed { ty: t },
+
+    "WellFormed" "(" <t:TraitRef<":">> ")" => DomainGoal::TraitRefWellFormed { trait_ref: t },
+
+    "FromEnv" "(" <t:Ty> ")" => DomainGoal::TyFromEnv { ty: t },
+
+    "FromEnv" "(" <t:TraitRef<":">> ")" => DomainGoal::TraitRefFromEnv { trait_ref: t },
+
+    // `<T as Foo>::U -> Bar` -- a normalization
+    "Normalize" "(" <s:ProjectionTy> "->" <t:Ty> ")" => DomainGoal::Normalize { projection: s, ty: t },
+
+    "InScope" "(" <t:Id> ")" => DomainGoal::TraitInScope { trait_name: t },
+
+    "Derefs" "(" <source:Ty> "," <target:Ty> ")" => DomainGoal::Derefs { source, target },
+
+    "IsLocal" "(" <ty:Ty> ")" => DomainGoal::IsLocal { ty },
+};
+
+LeafGoal: LeafGoal = {
+    <dg: DomainGoal> => LeafGoal::DomainGoal { goal: dg },
+
+    <a:Ty> "=" <b:Ty> => LeafGoal::UnifyTys { a, b },
+
+    <a:Lifetime> "=" <b:Lifetime> => LeafGoal::UnifyLifetimes { a, b },
 };
 
 TraitRef<S>: TraitRef = {

--- a/src/fold.rs
+++ b/src/fold.rs
@@ -423,9 +423,11 @@ macro_rules! enum_fold {
 
 enum_fold!(PolarizedTraitRef[] { Positive(a), Negative(a) });
 enum_fold!(ParameterKind[T,L] { Ty(a), Lifetime(a) } where T: Fold, L: Fold);
-enum_fold!(WhereClauseAtom[] { Implemented(a), ProjectionEq(a) });
+enum_fold!(WhereClause[] { Implemented(a), ProjectionEq(a) });
+enum_fold!(WellFormed[] { Trait(a), Ty(a) });
+enum_fold!(FromEnv[] { Trait(a), Ty(a) });
 enum_fold!(DomainGoal[] { Holds(a), WellFormed(a), FromEnv(a), Normalize(a), UnselectedNormalize(a),
-                          WellFormedTy(a), FromEnvTy(a), InScope(a), Derefs(a), IsLocal(a), LocalImplAllowed(a) });
+                          InScope(a), Derefs(a), IsLocal(a), LocalImplAllowed(a) });
 enum_fold!(LeafGoal[] { EqGoal(a), DomainGoal(a) });
 enum_fold!(Constraint[] { LifetimeEq(a, b) });
 enum_fold!(Goal[] { Quantified(qkind, subgoal), Implies(wc, subgoal), And(g1, g2), Not(g),

--- a/src/ir.rs
+++ b/src/ir.rs
@@ -295,7 +295,7 @@ impl TraitBound {
         vec![WhereClause::Implemented(trait_ref)]
     }
 
-    fn as_trait_ref(&self, self_ty: Ty) -> TraitRef {
+    crate fn as_trait_ref(&self, self_ty: Ty) -> TraitRef {
         let self_ty = ParameterKind::Ty(self_ty);
         TraitRef {
             trait_id: self.trait_id,

--- a/src/ir/debug.rs
+++ b/src/ir/debug.rs
@@ -169,17 +169,17 @@ impl Debug for UnselectedNormalize {
     }
 }
 
-impl Debug for WhereClauseAtom {
+impl Debug for WhereClause {
     fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
         match self {
-            WhereClauseAtom::Implemented(tr) => write!(
+            WhereClause::Implemented(tr) => write!(
                 fmt,
                 "Implemented({:?}: {:?}{:?})",
                 tr.parameters[0],
                 tr.trait_id,
                 Angle(&tr.parameters[1..])
             ),
-            WhereClauseAtom::ProjectionEq(p) => write!(fmt, "{:?}", p),
+            WhereClause::ProjectionEq(p) => write!(fmt, "{:?}", p),
         }
     }
 }
@@ -187,23 +187,11 @@ impl Debug for WhereClauseAtom {
 impl Debug for DomainGoal {
     fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
         match self {
-            DomainGoal::Holds(wca) => write!(fmt, "{:?}", wca),
-            DomainGoal::WellFormed(WhereClauseAtom::Implemented(tr)) => {
-                write!(fmt, "WellFormed({:?})", tr)
-            }
-            DomainGoal::WellFormed(WhereClauseAtom::ProjectionEq(p)) => {
-                write!(fmt, "WellFormed({:?})", p)
-            }
-            DomainGoal::FromEnv(WhereClauseAtom::Implemented(tr)) => {
-                write!(fmt, "FromEnv({:?})", tr)
-            }
-            DomainGoal::FromEnv(WhereClauseAtom::ProjectionEq(p)) => {
-                write!(fmt, "FromEnv({:?})", p)
-            }
+            DomainGoal::Holds(n) => write!(fmt, "{:?}", n),
+            DomainGoal::WellFormed(n) => write!(fmt, "{:?}", n),
+            DomainGoal::FromEnv(n) => write!(fmt, "{:?}", n),
             DomainGoal::Normalize(n) => write!(fmt, "{:?}", n),
             DomainGoal::UnselectedNormalize(n) => write!(fmt, "{:?}", n),
-            DomainGoal::WellFormedTy(t) => write!(fmt, "WellFormed({:?})", t),
-            DomainGoal::FromEnvTy(t) => write!(fmt, "FromEnv({:?})", t),
             DomainGoal::InScope(n) => write!(fmt, "InScope({:?})", n),
             DomainGoal::Derefs(n) => write!(fmt, "Derefs({:?})", n),
             DomainGoal::IsLocal(n) => write!(fmt, "IsLocal({:?})", n),

--- a/src/rules/wf/test.rs
+++ b/src/rules/wf/test.rs
@@ -206,7 +206,7 @@ fn wf_requiremements_for_projection() {
 }
 
 #[test]
-fn projection_type_in_header() {
+fn ill_formed_type_in_header() {
     lowering_error! {
         program {
             trait Foo {
@@ -215,8 +215,8 @@ fn projection_type_in_header() {
 
             trait Bar { }
 
-            // Projection types in an impl header are not assumed to be well-formed,
-            // an explicit where clause is needed (see below).
+            // Types in where clauses are not assumed to be well-formed,
+            // an explicit where clause would be needed (see below).
             impl<T> Bar for T where <T as Foo>::Value: Bar { }
         } error_msg {
             "trait impl for \"Bar\" does not meet well-formedness requirements"

--- a/src/zip.rs
+++ b/src/zip.rs
@@ -216,15 +216,15 @@ macro_rules! enum_zip {
 /// variant, then zips each field of the variant in turn. Only works
 /// if all variants have a single parenthesized value right now.
 enum_zip!(PolarizedTraitRef { Positive, Negative });
-enum_zip!(WhereClauseAtom { Implemented, ProjectionEq });
+enum_zip!(WhereClause { Implemented, ProjectionEq });
+enum_zip!(WellFormed { Trait, Ty });
+enum_zip!(FromEnv { Trait, Ty });
 enum_zip!(DomainGoal {
     Holds,
     WellFormed,
     FromEnv,
     Normalize,
     UnselectedNormalize,
-    WellFormedTy,
-    FromEnvTy,
     InScope,
     Derefs,
     IsLocal,


### PR DESCRIPTION
The `WhereClauseAtom` was formerly used for abstracting over bounds which also had `WF`/`FromEnv` versions (i.e. `Implemented` and `ProjectionEq` formerly).

We rename `WhereClauseAtom` to `WhereClause` and now use it for representing where clauses that can effectively be written by a Rust programmer. This helps for documentation and for cleaning up a bit some `match` blocks.

By the way, I refactored a bit the AST and the lowering process. This PR doesn't change the logic or whatever.

Closes #115.