### PR TITLE
Many lifetimes one universe

### DIFF
--- a/chalk-ir/src/debug.rs
+++ b/chalk-ir/src/debug.rs
@@ -30,7 +30,7 @@ impl Debug for TypeName {
     fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
         match self {
             TypeName::ItemId(id) => write!(fmt, "{:?}", id),
-            TypeName::ForAll(universe) => write!(fmt, "!{}", universe.counter),
+            TypeName::ForAll(universe) => write!(fmt, "!{}_{}", universe.ui.counter, universe.idx),
             TypeName::AssociatedType(assoc_ty) => write!(fmt, "{:?}", assoc_ty),
         }
     }

--- a/chalk-ir/src/debug.rs
+++ b/chalk-ir/src/debug.rs
@@ -60,7 +60,7 @@ impl Debug for Lifetime {
     fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
         match self {
             Lifetime::Var(depth) => write!(fmt, "'?{}", depth),
-            Lifetime::ForAll(universe) => write!(fmt, "'!{}", universe.counter),
+            Lifetime::ForAll(UniversalIndex { ui, idx }) => write!(fmt, "'!{}'{}", ui.counter, idx),
         }
     }
 }

--- a/chalk-ir/src/debug.rs
+++ b/chalk-ir/src/debug.rs
@@ -60,7 +60,7 @@ impl Debug for Lifetime {
     fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
         match self {
             Lifetime::Var(depth) => write!(fmt, "'?{}", depth),
-            Lifetime::ForAll(UniversalIndex { ui, idx }) => write!(fmt, "'!{}'{}", ui.counter, idx),
+            Lifetime::ForAll(UniversalIndex { ui, idx }) => write!(fmt, "'!{}_{}", ui.counter, idx),
         }
     }
 }

--- a/chalk-ir/src/fold.rs
+++ b/chalk-ir/src/fold.rs
@@ -135,7 +135,7 @@ pub trait UniversalFolder {
     ///
     /// - `universe` is the universe of the `TypeName::ForAll` that was found
     /// - `binders` is the number of binders in scope
-    fn fold_free_universal_ty(&mut self, universe: UniverseIndex, binders: usize) -> Fallible<Ty>;
+    fn fold_free_universal_ty(&mut self, universe: UniversalIndex, binders: usize) -> Fallible<Ty>;
 
     /// As with `fold_free_universal_ty`, but for lifetimes.
     fn fold_free_universal_lifetime(
@@ -151,8 +151,8 @@ pub trait UniversalFolder {
 pub trait IdentityUniversalFolder {}
 
 impl<T: IdentityUniversalFolder> UniversalFolder for T {
-    fn fold_free_universal_ty(&mut self, universe: UniverseIndex, _binders: usize) -> Fallible<Ty> {
-        Ok(TypeName::ForAll(universe).to_ty())
+    fn fold_free_universal_ty(&mut self, universe: UniversalIndex, _binders: usize) -> Fallible<Ty> {
+        Ok(universe.to_ty())
     }
 
     fn fold_free_universal_lifetime(

--- a/chalk-ir/src/fold.rs
+++ b/chalk-ir/src/fold.rs
@@ -349,7 +349,7 @@ pub fn super_fold_lifetime(
         } else {
             Ok(Lifetime::Var(depth))
         },
-        Lifetime::ForAll(universe) => folder.fold_free_universal_lifetime(universe, binders),
+        Lifetime::ForAll(universe) => folder.fold_free_universal_lifetime(universe.ui, binders),
     }
 }
 

--- a/chalk-ir/src/fold.rs
+++ b/chalk-ir/src/fold.rs
@@ -140,7 +140,7 @@ pub trait UniversalFolder {
     /// As with `fold_free_universal_ty`, but for lifetimes.
     fn fold_free_universal_lifetime(
         &mut self,
-        universe: UniverseIndex,
+        universe: UniversalIndex,
         binders: usize,
     ) -> Fallible<Lifetime>;
 }
@@ -157,7 +157,7 @@ impl<T: IdentityUniversalFolder> UniversalFolder for T {
 
     fn fold_free_universal_lifetime(
         &mut self,
-        universe: UniverseIndex,
+        universe: UniversalIndex,
         _binders: usize,
     ) -> Fallible<Lifetime> {
         Ok(universe.to_lifetime())
@@ -349,7 +349,7 @@ pub fn super_fold_lifetime(
         } else {
             Ok(Lifetime::Var(depth))
         },
-        Lifetime::ForAll(universe) => folder.fold_free_universal_lifetime(universe.ui, binders),
+        Lifetime::ForAll(universe) => folder.fold_free_universal_lifetime(universe, binders),
     }
 }
 

--- a/chalk-ir/src/lib.rs
+++ b/chalk-ir/src/lib.rs
@@ -96,19 +96,10 @@ pub enum TypeName {
     ItemId(ItemId),
 
     /// skolemized form of a type parameter like `T`
-    ForAll(UniverseIndex),
+    ForAll(UniversalIndex),
 
     /// an associated type like `Iterator::Item`; see `AssociatedType` for details
     AssociatedType(ItemId),
-}
-
-impl TypeName {
-    pub fn to_ty(self) -> Ty {
-        Ty::Apply(ApplicationTy {
-            name: self,
-            parameters: vec![],
-        })
-    }
 }
 
 /// An universe index is how a universally quantified parameter is
@@ -219,6 +210,13 @@ pub struct UniversalIndex {
 impl UniversalIndex {
     pub fn to_lifetime(self) -> Lifetime {
         Lifetime::ForAll(self)
+    }
+
+    pub fn to_ty(self) -> Ty {
+        Ty::Apply(ApplicationTy {
+            name: TypeName::ForAll(self),
+            parameters: vec![],
+        })
     }
 }
 

--- a/chalk-ir/src/lib.rs
+++ b/chalk-ir/src/lib.rs
@@ -134,10 +134,6 @@ impl UniverseIndex {
         self.counter >= ui.counter
     }
 
-    pub fn to_lifetime(self) -> Lifetime {
-        Lifetime::ForAll(UniversalIndex { ui: self, idx: 0 })
-    }
-
     pub fn next(self) -> UniverseIndex {
         UniverseIndex {
             counter: self.counter + 1,
@@ -218,6 +214,12 @@ pub struct UniversalIndex {
     pub ui: UniverseIndex,
     /// Index *in* the universe.
     pub idx: usize,
+}
+
+impl UniversalIndex {
+    pub fn to_lifetime(self) -> Lifetime {
+        Lifetime::ForAll(self)
+    }
 }
 
 #[derive(Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]

--- a/chalk-ir/src/lib.rs
+++ b/chalk-ir/src/lib.rs
@@ -135,7 +135,7 @@ impl UniverseIndex {
     }
 
     pub fn to_lifetime(self) -> Lifetime {
-        Lifetime::ForAll(self)
+        Lifetime::ForAll(UniversalIndex { ui: self, idx: 0 })
     }
 
     pub fn next(self) -> UniverseIndex {
@@ -206,7 +206,18 @@ pub struct QuantifiedTy {
 pub enum Lifetime {
     /// See Ty::Var(_).
     Var(usize),
-    ForAll(UniverseIndex),
+    ForAll(UniversalIndex),
+}
+
+/// Index of an universally quantified parameter in the environment.
+/// Two indexes are required, the one of the universe itself
+/// and the relative index inside the universe.
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct UniversalIndex {
+    /// Index *of* the universe.
+    pub ui: UniverseIndex,
+    /// Index *in* the universe.
+    pub idx: usize,
 }
 
 #[derive(Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]

--- a/chalk-ir/src/macros.rs
+++ b/chalk-ir/src/macros.rs
@@ -69,5 +69,10 @@ macro_rules! lifetime {
 #[macro_export]
 macro_rules! ty_name {
     ((item $n:expr)) => { $crate::TypeName::ItemId(ItemId { index: $n }) };
-    ((skol $n:expr)) => { $crate::TypeName::ForAll(UniverseIndex { counter: $n }) }
+    ((skol $n:expr)) => { $crate::TypeName::ForAll(
+                            UniversalIndex {
+                                ui: UniverseIndex { counter: $n },
+                                idx: 0,
+                            })
+                        }
 }

--- a/chalk-ir/src/macros.rs
+++ b/chalk-ir/src/macros.rs
@@ -54,7 +54,7 @@ macro_rules! lifetime {
     };
 
     (skol $b:expr) => {
-        $crate::Lifetime::ForAll(UniverseIndex { counter: $b })
+        $crate::Lifetime::ForAll(UniversalIndex { ui: UniverseIndex { counter: $b }, idx: 0})
     };
 
     (expr $b:expr) => {

--- a/chalk-solve/src/infer/canonicalize.rs
+++ b/chalk-solve/src/infer/canonicalize.rs
@@ -94,9 +94,9 @@ impl<'q> Canonicalizer<'q> {
 impl<'q> DefaultTypeFolder for Canonicalizer<'q> {}
 
 impl<'q> UniversalFolder for Canonicalizer<'q> {
-    fn fold_free_universal_ty(&mut self, universe: UniverseIndex, _binders: usize) -> Fallible<Ty> {
-        self.max_universe = max(self.max_universe, universe);
-        Ok(TypeName::ForAll(universe).to_ty())
+    fn fold_free_universal_ty(&mut self, universe: UniversalIndex, _binders: usize) -> Fallible<Ty> {
+        self.max_universe = max(self.max_universe, universe.ui);
+        Ok(universe.to_ty())
     }
 
     fn fold_free_universal_lifetime(

--- a/chalk-solve/src/infer/canonicalize.rs
+++ b/chalk-solve/src/infer/canonicalize.rs
@@ -101,10 +101,10 @@ impl<'q> UniversalFolder for Canonicalizer<'q> {
 
     fn fold_free_universal_lifetime(
         &mut self,
-        universe: UniverseIndex,
+        universe: UniversalIndex,
         _binders: usize,
     ) -> Fallible<Lifetime> {
-        self.max_universe = max(self.max_universe, universe);
+        self.max_universe = max(self.max_universe, universe.ui);
         Ok(universe.to_lifetime())
     }
 }

--- a/chalk-solve/src/infer/instantiate.rs
+++ b/chalk-solve/src/infer/instantiate.rs
@@ -106,7 +106,7 @@ impl InferenceTable {
                 let new_universe = self.new_universe();
                 match *pk {
                     ParameterKind::Lifetime(()) => {
-                        let lt = Lifetime::ForAll(new_universe);
+                        let lt = Lifetime::ForAll(UniversalIndex { ui: new_universe, idx: 0 });
                         ParameterKind::Lifetime(lt)
                     }
                     ParameterKind::Ty(()) => ParameterKind::Ty(Ty::Apply(ApplicationTy {

--- a/chalk-solve/src/infer/invert.rs
+++ b/chalk-solve/src/infer/invert.rs
@@ -97,7 +97,7 @@ impl InferenceTable {
 
 struct Inverter<'q> {
     table: &'q mut InferenceTable,
-    inverted_ty: HashMap<UniverseIndex, InferenceVariable>,
+    inverted_ty: HashMap<UniversalIndex, InferenceVariable>,
     inverted_lifetime: HashMap<UniversalIndex, InferenceVariable>,
 }
 
@@ -114,12 +114,12 @@ impl<'q> Inverter<'q> {
 impl<'q> DefaultTypeFolder for Inverter<'q> {}
 
 impl<'q> UniversalFolder for Inverter<'q> {
-    fn fold_free_universal_ty(&mut self, universe: UniverseIndex, binders: usize) -> Fallible<Ty> {
+    fn fold_free_universal_ty(&mut self, universe: UniversalIndex, binders: usize) -> Fallible<Ty> {
         let table = &mut self.table;
         Ok(
             self.inverted_ty
                 .entry(universe)
-                .or_insert_with(|| table.new_variable(universe))
+                .or_insert_with(|| table.new_variable(universe.ui))
                 .to_ty()
                 .shifted_in(binders),
         )

--- a/chalk-solve/src/infer/invert.rs
+++ b/chalk-solve/src/infer/invert.rs
@@ -98,7 +98,7 @@ impl InferenceTable {
 struct Inverter<'q> {
     table: &'q mut InferenceTable,
     inverted_ty: HashMap<UniverseIndex, InferenceVariable>,
-    inverted_lifetime: HashMap<UniverseIndex, InferenceVariable>,
+    inverted_lifetime: HashMap<UniversalIndex, InferenceVariable>,
 }
 
 impl<'q> Inverter<'q> {
@@ -127,14 +127,14 @@ impl<'q> UniversalFolder for Inverter<'q> {
 
     fn fold_free_universal_lifetime(
         &mut self,
-        universe: UniverseIndex,
+        universe: UniversalIndex,
         binders: usize,
     ) -> Fallible<Lifetime> {
         let table = &mut self.table;
         Ok(
             self.inverted_lifetime
                 .entry(universe)
-                .or_insert_with(|| table.new_variable(universe))
+                .or_insert_with(|| table.new_variable(universe.ui))
                 .to_lifetime()
                 .shifted_in(binders),
         )

--- a/chalk-solve/src/infer/test.rs
+++ b/chalk-solve/src/infer/test.rs
@@ -294,6 +294,6 @@ fn lifetime_constraint_indirect() {
     assert_eq!(constraints.len(), 1);
     assert_eq!(
         format!("{:?}", constraints[0]),
-        "InEnvironment { environment: Env([]), goal: \'?2 == \'!1 }",
+        "InEnvironment { environment: Env([]), goal: \'?2 == \'!1'0 }",
     );
 }

--- a/chalk-solve/src/infer/test.rs
+++ b/chalk-solve/src/infer/test.rs
@@ -294,6 +294,6 @@ fn lifetime_constraint_indirect() {
     assert_eq!(constraints.len(), 1);
     assert_eq!(
         format!("{:?}", constraints[0]),
-        "InEnvironment { environment: Env([]), goal: \'?2 == \'!1'0 }",
+        "InEnvironment { environment: Env([]), goal: \'?2 == \'!1_0 }",
     );
 }

--- a/chalk-solve/src/infer/ucanonicalize.rs
+++ b/chalk-solve/src/infer/ucanonicalize.rs
@@ -227,10 +227,10 @@ impl<'q> UniversalFolder for UCollector<'q> {
 
     fn fold_free_universal_lifetime(
         &mut self,
-        universe: UniverseIndex,
+        universe: UniversalIndex,
         _binders: usize,
     ) -> Fallible<Lifetime> {
-        self.universes.add(universe);
+        self.universes.add(universe.ui);
         Ok(universe.to_lifetime())
     }
 }
@@ -255,11 +255,11 @@ impl<'q> UniversalFolder for UMapToCanonical<'q> {
 
     fn fold_free_universal_lifetime(
         &mut self,
-        universe0: UniverseIndex,
+        universe0: UniversalIndex,
         _binders: usize,
     ) -> Fallible<Lifetime> {
-        let universe = self.universes.map_universe_to_canonical(universe0);
-        Ok(universe.to_lifetime())
+        let universe = self.universes.map_universe_to_canonical(universe0.ui);
+        Ok(UniversalIndex { ui: universe, idx: universe0.idx }.to_lifetime())
     }
 }
 
@@ -283,11 +283,11 @@ impl<'q> UniversalFolder for UMapFromCanonical<'q> {
 
     fn fold_free_universal_lifetime(
         &mut self,
-        universe0: UniverseIndex,
+        universe0: UniversalIndex,
         _binders: usize,
     ) -> Fallible<Lifetime> {
-        let universe = self.universes.map_universe_from_canonical(universe0);
-        Ok(universe.to_lifetime())
+        let universe = self.universes.map_universe_from_canonical(universe0.ui);
+        Ok(UniversalIndex { ui: universe, idx: universe0.idx }.to_lifetime())
     }
 }
 

--- a/chalk-solve/src/infer/ucanonicalize.rs
+++ b/chalk-solve/src/infer/ucanonicalize.rs
@@ -220,9 +220,9 @@ struct UCollector<'q> {
 impl<'q> DefaultTypeFolder for UCollector<'q> {}
 
 impl<'q> UniversalFolder for UCollector<'q> {
-    fn fold_free_universal_ty(&mut self, universe: UniverseIndex, _binders: usize) -> Fallible<Ty> {
-        self.universes.add(universe);
-        Ok(TypeName::ForAll(universe).to_ty())
+    fn fold_free_universal_ty(&mut self, universe: UniversalIndex, _binders: usize) -> Fallible<Ty> {
+        self.universes.add(universe.ui);
+        Ok(universe.to_ty())
     }
 
     fn fold_free_universal_lifetime(
@@ -246,11 +246,11 @@ impl<'q> DefaultTypeFolder for UMapToCanonical<'q> {}
 impl<'q> UniversalFolder for UMapToCanonical<'q> {
     fn fold_free_universal_ty(
         &mut self,
-        universe0: UniverseIndex,
+        universe0: UniversalIndex,
         _binders: usize,
     ) -> Fallible<Ty> {
-        let universe = self.universes.map_universe_to_canonical(universe0);
-        Ok(TypeName::ForAll(universe).to_ty())
+        let ui = self.universes.map_universe_to_canonical(universe0.ui);
+        Ok(UniversalIndex { ui, idx: universe0.idx }.to_ty())
     }
 
     fn fold_free_universal_lifetime(
@@ -274,11 +274,11 @@ impl<'q> DefaultTypeFolder for UMapFromCanonical<'q> {}
 impl<'q> UniversalFolder for UMapFromCanonical<'q> {
     fn fold_free_universal_ty(
         &mut self,
-        universe0: UniverseIndex,
+        universe0: UniversalIndex,
         _binders: usize,
     ) -> Fallible<Ty> {
-        let universe = self.universes.map_universe_from_canonical(universe0);
-        Ok(TypeName::ForAll(universe).to_ty())
+        let ui = self.universes.map_universe_from_canonical(universe0.ui);
+        Ok(UniversalIndex { ui, idx: universe0.idx }.to_ty())
     }
 
     fn fold_free_universal_lifetime(

--- a/chalk-solve/src/infer/unify.rs
+++ b/chalk-solve/src/infer/unify.rs
@@ -242,10 +242,10 @@ impl<'t> Unifier<'t> {
     }
 
     fn unify_forall_apply(&mut self, ty1: &QuantifiedTy, ty2: &Ty) -> Fallible<()> {
+        let ui = self.table.new_universe();
         let lifetimes1: Vec<_> = (0..ty1.num_binders)
-            .map(|_| {
-                let new_universe = self.table.new_universe();
-                Lifetime::ForAll(UniversalIndex { ui: new_universe, idx: 0 }).cast()
+            .map(|idx| {
+                Lifetime::ForAll(UniversalIndex { ui, idx }).cast()
             })
             .collect();
 

--- a/chalk-solve/src/infer/unify.rs
+++ b/chalk-solve/src/infer/unify.rs
@@ -166,19 +166,22 @@ impl<'t> Unifier<'t> {
     }
 
     fn unify_forall_tys(&mut self, ty1: &QuantifiedTy, ty2: &QuantifiedTy) -> Fallible<()> {
-        // for<'a...> T == for<'b...> U where 'a != 'b
+        // for<'a...> T == for<'b...> U
         //
         // if:
         //
         // for<'a...> exists<'b...> T == U &&
         // for<'b...> exists<'a...> T == U
+        //
+        // Here we only check for<'a...> exists<'b...> T == U,
+        // can someone smart comment why this is sufficient?
 
         debug!("unify_forall_tys({:?}, {:?})", ty1, ty2);
 
+        let ui = self.table.new_universe();
         let lifetimes1: Vec<_> = (0..ty1.num_binders)
-            .map(|_| {
-                let new_universe = self.table.new_universe();
-                Lifetime::ForAll(UniversalIndex { ui: new_universe, idx: 0 }).cast()
+            .map(|idx| {
+                Lifetime::ForAll(UniversalIndex { ui, idx }).cast()
             })
             .collect();
 

--- a/chalk-solve/src/infer/unify.rs
+++ b/chalk-solve/src/infer/unify.rs
@@ -377,11 +377,11 @@ impl<'u, 't> OccursCheck<'u, 't> {
 impl<'u, 't> DefaultTypeFolder for OccursCheck<'u, 't> {}
 
 impl<'u, 't> UniversalFolder for OccursCheck<'u, 't> {
-    fn fold_free_universal_ty(&mut self, universe: UniverseIndex, _binders: usize) -> Fallible<Ty> {
-        if self.universe_index < universe {
+    fn fold_free_universal_ty(&mut self, universe: UniversalIndex, _binders: usize) -> Fallible<Ty> {
+        if self.universe_index < universe.ui {
             Err(NoSolution)
         } else {
-            Ok(TypeName::ForAll(universe).to_ty()) // no need to shift, not relative to depth
+            Ok(universe.to_ty()) // no need to shift, not relative to depth
         }
     }
 

--- a/chalk-solve/src/infer/unify.rs
+++ b/chalk-solve/src/infer/unify.rs
@@ -384,10 +384,10 @@ impl<'u, 't> UniversalFolder for OccursCheck<'u, 't> {
 
     fn fold_free_universal_lifetime(
         &mut self,
-        ui: UniverseIndex,
+        ui: UniversalIndex,
         binders: usize,
     ) -> Fallible<Lifetime> {
-        if self.universe_index < ui {
+        if self.universe_index < ui.ui {
             // Scenario is like:
             //
             // exists<T> forall<'b> ?T = Foo<'b>

--- a/chalk-solve/src/solve/slg/implementation/aggregate.rs
+++ b/chalk-solve/src/solve/slg/implementation/aggregate.rs
@@ -320,8 +320,8 @@ impl<'infer> AntiUnifier<'infer> {
         match (l1, l2) {
             (Lifetime::Var(_), _) | (_, Lifetime::Var(_)) => self.new_lifetime_variable(),
 
-            (Lifetime::ForAll(ui1), Lifetime::ForAll(ui2)) => if ui1 == ui2 {
-                Lifetime::ForAll(*ui1)
+            (Lifetime::ForAll(_), Lifetime::ForAll(_)) => if l1 == l2 {
+                *l1
             } else {
                 self.new_lifetime_variable()
             },

--- a/chalk-solve/src/solve/slg/implementation/resolvent.rs
+++ b/chalk-solve/src/solve/slg/implementation/resolvent.rs
@@ -388,8 +388,8 @@ impl<'t> Zipper for AnswerSubstitutor<'t> {
                 self.assert_matching_vars(*answer_depth, *pending_depth)
             }
 
-            (Lifetime::ForAll(answer_ui), Lifetime::ForAll(pending_ui)) => {
-                assert_eq!(answer_ui, pending_ui);
+            (Lifetime::ForAll(_), Lifetime::ForAll(_)) => {
+                assert_eq!(answer, pending);
                 Ok(())
             }
 

--- a/chalk-solve/src/solve/slg/test.rs
+++ b/chalk-solve/src/solve/slg/test.rs
@@ -550,7 +550,7 @@ fn basic_region_constraint_from_positive_impl() {
                             constraints: [
                                 InEnvironment {
                                     environment: Env([]),
-                                    goal: '!2 == '!1
+                                    goal: '!2'0 == '!1'0
                                 }
                             ]
                         },

--- a/chalk-solve/src/solve/slg/test.rs
+++ b/chalk-solve/src/solve/slg/test.rs
@@ -550,7 +550,7 @@ fn basic_region_constraint_from_positive_impl() {
                             constraints: [
                                 InEnvironment {
                                     environment: Env([]),
-                                    goal: '!1'1 == '!1'0
+                                    goal: '!1_1 == '!1_0
                                 }
                             ]
                         },

--- a/chalk-solve/src/solve/slg/test.rs
+++ b/chalk-solve/src/solve/slg/test.rs
@@ -482,7 +482,7 @@ fn subgoal_cycle_uninhabited() {
                 Answer {
                     subst: Canonical {
                         value: ConstrainedSubst {
-                            subst: [?0 := !1],
+                            subst: [?0 := !1_0],
                             constraints: []
                         },
                         binders: []

--- a/chalk-solve/src/solve/slg/test.rs
+++ b/chalk-solve/src/solve/slg/test.rs
@@ -550,7 +550,7 @@ fn basic_region_constraint_from_positive_impl() {
                             constraints: [
                                 InEnvironment {
                                     environment: Env([]),
-                                    goal: '!2'0 == '!1'0
+                                    goal: '!1'1 == '!1'0
                                 }
                             ]
                         },

--- a/chalk-solve/src/solve/test.rs
+++ b/chalk-solve/src/solve/test.rs
@@ -581,7 +581,7 @@ fn normalize_gat1() {
                 }
             }
         } yields {
-            "Unique; substitution [?0 := Iter<'!2, !1>], lifetime constraints []"
+            "Unique; substitution [?0 := Iter<'!2'0, !1>], lifetime constraints []"
         }
     }
 }
@@ -606,7 +606,7 @@ fn normalize_gat2() {
                 }
             }
         } yields {
-            "Unique; substitution [?0 := Span<'!1, !2>], lifetime constraints []"
+            "Unique; substitution [?0 := Span<'!1'0, !2>], lifetime constraints []"
         }
 
         goal {
@@ -922,7 +922,7 @@ fn region_equality() {
         } yields {
             "Unique; substitution [],
                      lifetime constraints \
-                     [InEnvironment { environment: Env([]), goal: '!2 == '!1 }]
+                     [InEnvironment { environment: Env([]), goal: '!2'0 == '!1'0 }]
                      "
         }
 
@@ -933,7 +933,7 @@ fn region_equality() {
                 }
             }
         } yields {
-            "Unique; substitution [?0 := '!1], lifetime constraints []"
+            "Unique; substitution [?0 := '!1'0], lifetime constraints []"
         }
     }
 }
@@ -971,7 +971,7 @@ fn forall_equality() {
                 for<'c, 'd> Ref<'c, Ref<'d, Ref<'d, Unit>>>>
         } yields {
             "Unique; substitution [], lifetime constraints [
-                 InEnvironment { environment: Env([]), goal: '!2 == '!1 }
+                 InEnvironment { environment: Env([]), goal: '!2'0 == '!1'0 }
              ]"
         }
     }
@@ -1185,7 +1185,7 @@ fn normalize_under_binder() {
                 }
             }
         } yields {
-            "Unique; substitution [?0 := Ref<'!1, I32>], lifetime constraints []"
+            "Unique; substitution [?0 := Ref<'!1'0, I32>], lifetime constraints []"
         }
 
         goal {
@@ -1197,7 +1197,7 @@ fn normalize_under_binder() {
         } yields {
             "Unique; for<?U0> { \
              substitution [?0 := Ref<'?0, I32>], \
-             lifetime constraints [InEnvironment { environment: Env([]), goal: '?0 == '!1 }] \
+             lifetime constraints [InEnvironment { environment: Env([]), goal: '?0 == '!1'0 }] \
              }"
         }
     }
@@ -1221,7 +1221,7 @@ fn unify_quantified_lifetimes() {
         } yields {
             "Unique; for<?U0> { \
              substitution [?0 := '?0], \
-             lifetime constraints [InEnvironment { environment: Env([]), goal: '?0 == '!1 }] \
+             lifetime constraints [InEnvironment { environment: Env([]), goal: '?0 == '!1'0 }] \
              }"
         }
 
@@ -1237,8 +1237,8 @@ fn unify_quantified_lifetimes() {
             }
         } yields {
             "Unique; for<?U0> { \
-             substitution [?0 := '?0, ?1 := '!1], \
-             lifetime constraints [InEnvironment { environment: Env([]), goal: '?0 == '!1 }] \
+             substitution [?0 := '?0, ?1 := '!1'0], \
+             lifetime constraints [InEnvironment { environment: Env([]), goal: '?0 == '!1'0 }] \
              }"
         }
     }
@@ -1263,7 +1263,7 @@ fn equality_binder() {
         } yields {
             "Unique; for<?U1> { \
                  substitution [?0 := '?0], \
-                 lifetime constraints [InEnvironment { environment: Env([]), goal: '!2 == '?0 }] \
+                 lifetime constraints [InEnvironment { environment: Env([]), goal: '!2'0 == '?0 }] \
              }"
         }
     }
@@ -2394,7 +2394,7 @@ fn quantified_types() {
         } yields {
             // Lifetime constraints are unsatisfiable
             "Unique; substitution [], \
-            lifetime constraints [InEnvironment { environment: Env([]), goal: '!2 == '!1 }]"
+            lifetime constraints [InEnvironment { environment: Env([]), goal: '!2'0 == '!1'0 }]"
         }
     }
 }

--- a/chalk-solve/src/solve/test.rs
+++ b/chalk-solve/src/solve/test.rs
@@ -476,7 +476,7 @@ fn normalize_basic() {
                 }
             }
         } yields {
-            "Unique; substitution [?0 := !1], lifetime constraints []"
+            "Unique; substitution [?0 := !1_0], lifetime constraints []"
         }
 
         goal {
@@ -506,7 +506,7 @@ fn normalize_basic() {
                 }
             }
         } yields {
-            "Unique; substitution [?0 := (Iterator::Item)<!1>]"
+            "Unique; substitution [?0 := (Iterator::Item)<!1_0>]"
         }
 
         goal {
@@ -518,7 +518,7 @@ fn normalize_basic() {
                 }
             }
         } yields {
-            "Unique; substitution [?0 := (Iterator::Item)<!1>]"
+            "Unique; substitution [?0 := (Iterator::Item)<!1_0>]"
         }
 
         goal {
@@ -581,7 +581,7 @@ fn normalize_gat1() {
                 }
             }
         } yields {
-            "Unique; substitution [?0 := Iter<'!2_0, !1>], lifetime constraints []"
+            "Unique; substitution [?0 := Iter<'!2_0, !1_0>], lifetime constraints []"
         }
     }
 }
@@ -606,7 +606,7 @@ fn normalize_gat2() {
                 }
             }
         } yields {
-            "Unique; substitution [?0 := Span<'!1_0, !2>], lifetime constraints []"
+            "Unique; substitution [?0 := Span<'!1_0, !1_1>], lifetime constraints []"
         }
 
         goal {
@@ -664,7 +664,7 @@ fn normalize_gat_with_where_clause() {
                 }
             }
         } yields {
-            "Unique; substitution [?0 := Value<!1>]"
+            "Unique; substitution [?0 := Value<!1_0>]"
         }
     }
 }
@@ -703,7 +703,7 @@ fn normalize_gat_with_where_clause2() {
                 }
             }
         } yields {
-            "Unique; substitution [?0 := !2]"
+            "Unique; substitution [?0 := !1_1]"
         }
     }
 }

--- a/chalk-solve/src/solve/test.rs
+++ b/chalk-solve/src/solve/test.rs
@@ -922,7 +922,7 @@ fn region_equality() {
         } yields {
             "Unique; substitution [],
                      lifetime constraints \
-                     [InEnvironment { environment: Env([]), goal: '!2'0 == '!1'0 }]
+                     [InEnvironment { environment: Env([]), goal: '!1'1 == '!1'0 }]
                      "
         }
 
@@ -966,12 +966,12 @@ fn forall_equality() {
             // this is because the region constraints are unsolvable.
             //
             // Note that `?0` (in universe 2) must be equal to both
-            // `!1` and `!2`, which of course it cannot be.
+            // `!1'0` and `!1'1`, which of course it cannot be.
             for<'a, 'b> Ref<'a, Ref<'b, Ref<'a, Unit>>>: Eq<
                 for<'c, 'd> Ref<'c, Ref<'d, Ref<'d, Unit>>>>
         } yields {
             "Unique; substitution [], lifetime constraints [
-                 InEnvironment { environment: Env([]), goal: '!2'0 == '!1'0 }
+                 InEnvironment { environment: Env([]), goal: '!1'1 == '!1'0 }
              ]"
         }
     }

--- a/chalk-solve/src/solve/test.rs
+++ b/chalk-solve/src/solve/test.rs
@@ -581,7 +581,7 @@ fn normalize_gat1() {
                 }
             }
         } yields {
-            "Unique; substitution [?0 := Iter<'!2'0, !1>], lifetime constraints []"
+            "Unique; substitution [?0 := Iter<'!2_0, !1>], lifetime constraints []"
         }
     }
 }
@@ -606,7 +606,7 @@ fn normalize_gat2() {
                 }
             }
         } yields {
-            "Unique; substitution [?0 := Span<'!1'0, !2>], lifetime constraints []"
+            "Unique; substitution [?0 := Span<'!1_0, !2>], lifetime constraints []"
         }
 
         goal {
@@ -922,7 +922,7 @@ fn region_equality() {
         } yields {
             "Unique; substitution [],
                      lifetime constraints \
-                     [InEnvironment { environment: Env([]), goal: '!1'1 == '!1'0 }]
+                     [InEnvironment { environment: Env([]), goal: '!1_1 == '!1_0 }]
                      "
         }
 
@@ -933,7 +933,7 @@ fn region_equality() {
                 }
             }
         } yields {
-            "Unique; substitution [?0 := '!1'0], lifetime constraints []"
+            "Unique; substitution [?0 := '!1_0], lifetime constraints []"
         }
     }
 }
@@ -966,12 +966,12 @@ fn forall_equality() {
             // this is because the region constraints are unsolvable.
             //
             // Note that `?0` (in universe 2) must be equal to both
-            // `!1'0` and `!1'1`, which of course it cannot be.
+            // `!1_0` and `!1_1`, which of course it cannot be.
             for<'a, 'b> Ref<'a, Ref<'b, Ref<'a, Unit>>>: Eq<
                 for<'c, 'd> Ref<'c, Ref<'d, Ref<'d, Unit>>>>
         } yields {
             "Unique; substitution [], lifetime constraints [
-                 InEnvironment { environment: Env([]), goal: '!1'1 == '!1'0 }
+                 InEnvironment { environment: Env([]), goal: '!1_1 == '!1_0 }
              ]"
         }
     }
@@ -1185,7 +1185,7 @@ fn normalize_under_binder() {
                 }
             }
         } yields {
-            "Unique; substitution [?0 := Ref<'!1'0, I32>], lifetime constraints []"
+            "Unique; substitution [?0 := Ref<'!1_0, I32>], lifetime constraints []"
         }
 
         goal {
@@ -1197,7 +1197,7 @@ fn normalize_under_binder() {
         } yields {
             "Unique; for<?U0> { \
              substitution [?0 := Ref<'?0, I32>], \
-             lifetime constraints [InEnvironment { environment: Env([]), goal: '?0 == '!1'0 }] \
+             lifetime constraints [InEnvironment { environment: Env([]), goal: '?0 == '!1_0 }] \
              }"
         }
     }
@@ -1221,7 +1221,7 @@ fn unify_quantified_lifetimes() {
         } yields {
             "Unique; for<?U0> { \
              substitution [?0 := '?0], \
-             lifetime constraints [InEnvironment { environment: Env([]), goal: '?0 == '!1'0 }] \
+             lifetime constraints [InEnvironment { environment: Env([]), goal: '?0 == '!1_0 }] \
              }"
         }
 
@@ -1237,8 +1237,8 @@ fn unify_quantified_lifetimes() {
             }
         } yields {
             "Unique; for<?U0> { \
-             substitution [?0 := '?0, ?1 := '!1'0], \
-             lifetime constraints [InEnvironment { environment: Env([]), goal: '?0 == '!1'0 }] \
+             substitution [?0 := '?0, ?1 := '!1_0], \
+             lifetime constraints [InEnvironment { environment: Env([]), goal: '?0 == '!1_0 }] \
              }"
         }
     }
@@ -1263,7 +1263,7 @@ fn equality_binder() {
         } yields {
             "Unique; for<?U1> { \
                  substitution [?0 := '?0], \
-                 lifetime constraints [InEnvironment { environment: Env([]), goal: '!2'0 == '?0 }] \
+                 lifetime constraints [InEnvironment { environment: Env([]), goal: '!2_0 == '?0 }] \
              }"
         }
     }
@@ -2394,7 +2394,7 @@ fn quantified_types() {
         } yields {
             // Lifetime constraints are unsatisfiable
             "Unique; substitution [], \
-            lifetime constraints [InEnvironment { environment: Env([]), goal: '!2'0 == '!1'0 }]"
+            lifetime constraints [InEnvironment { environment: Env([]), goal: '!2_0 == '!1_0 }]"
         }
     }
 }

--- a/src/test.rs
+++ b/src/test.rs
@@ -478,7 +478,7 @@ fn normalize_basic() {
                 }
             }
         } yields {
-            "Unique; substitution [?0 := !1], lifetime constraints []"
+            "Unique; substitution [?0 := !1_0], lifetime constraints []"
         }
 
         goal {
@@ -508,7 +508,7 @@ fn normalize_basic() {
                 }
             }
         } yields {
-            "Unique; substitution [?0 := (Iterator::Item)<!1>]"
+            "Unique; substitution [?0 := (Iterator::Item)<!1_0>]"
         }
 
         goal {
@@ -520,7 +520,7 @@ fn normalize_basic() {
                 }
             }
         } yields {
-            "Unique; substitution [?0 := (Iterator::Item)<!1>]"
+            "Unique; substitution [?0 := (Iterator::Item)<!1_0>]"
         }
 
         goal {
@@ -583,7 +583,7 @@ fn normalize_gat1() {
                 }
             }
         } yields {
-            "Unique; substitution [?0 := Iter<'!2, !1>], lifetime constraints []"
+            "Unique; substitution [?0 := Iter<'!2_0, !1_0>], lifetime constraints []"
         }
     }
 }
@@ -608,7 +608,7 @@ fn normalize_gat2() {
                 }
             }
         } yields {
-            "Unique; substitution [?0 := Span<'!1, !2>], lifetime constraints []"
+            "Unique; substitution [?0 := Span<'!1_0, !1_1>], lifetime constraints []"
         }
 
         goal {
@@ -666,7 +666,7 @@ fn normalize_gat_with_where_clause() {
                 }
             }
         } yields {
-            "Unique; substitution [?0 := Value<!1>]"
+            "Unique; substitution [?0 := Value<!1_0>]"
         }
     }
 }
@@ -705,7 +705,7 @@ fn normalize_gat_with_where_clause2() {
                 }
             }
         } yields {
-            "Unique; substitution [?0 := !2]"
+            "Unique; substitution [?0 := !1_1]"
         }
     }
 }
@@ -924,7 +924,7 @@ fn region_equality() {
         } yields {
             "Unique; substitution [],
                      lifetime constraints \
-                     [InEnvironment { environment: Env([]), goal: '!2 == '!1 }]
+                     [InEnvironment { environment: Env([]), goal: '!1_1 == '!1_0 }]
                      "
         }
 
@@ -935,7 +935,7 @@ fn region_equality() {
                 }
             }
         } yields {
-            "Unique; substitution [?0 := '!1], lifetime constraints []"
+            "Unique; substitution [?0 := '!1_0], lifetime constraints []"
         }
     }
 }
@@ -968,12 +968,12 @@ fn forall_equality() {
             // this is because the region constraints are unsolvable.
             //
             // Note that `?0` (in universe 2) must be equal to both
-            // `!1` and `!2`, which of course it cannot be.
+            // `!1_0` and `!1_1`, which of course it cannot be.
             for<'a, 'b> Ref<'a, Ref<'b, Ref<'a, Unit>>>: Eq<
                 for<'c, 'd> Ref<'c, Ref<'d, Ref<'d, Unit>>>>
         } yields {
             "Unique; substitution [], lifetime constraints [
-                 InEnvironment { environment: Env([]), goal: '!2 == '!1 }
+                 InEnvironment { environment: Env([]), goal: '!1_1 == '!1_0 }
              ]"
         }
     }
@@ -1187,7 +1187,7 @@ fn normalize_under_binder() {
                 }
             }
         } yields {
-            "Unique; substitution [?0 := Ref<'!1, I32>], lifetime constraints []"
+            "Unique; substitution [?0 := Ref<'!1_0, I32>], lifetime constraints []"
         }
 
         goal {
@@ -1199,7 +1199,7 @@ fn normalize_under_binder() {
         } yields {
             "Unique; for<?U0> { \
              substitution [?0 := Ref<'?0, I32>], \
-             lifetime constraints [InEnvironment { environment: Env([]), goal: '?0 == '!1 }] \
+             lifetime constraints [InEnvironment { environment: Env([]), goal: '?0 == '!1_0 }] \
              }"
         }
     }
@@ -1212,7 +1212,7 @@ fn unify_quantified_lifetimes() {
         }
 
         // Check that `'a` (here, `'?0`) is not unified
-        // with `'!1`, because they belong to incompatible
+        // with `'!1_0`, because they belong to incompatible
         // universes.
         goal {
             exists<'a> {
@@ -1223,7 +1223,7 @@ fn unify_quantified_lifetimes() {
         } yields {
             "Unique; for<?U0> { \
              substitution [?0 := '?0], \
-             lifetime constraints [InEnvironment { environment: Env([]), goal: '?0 == '!1 }] \
+             lifetime constraints [InEnvironment { environment: Env([]), goal: '?0 == '!1_0 }] \
              }"
         }
 
@@ -1239,8 +1239,8 @@ fn unify_quantified_lifetimes() {
             }
         } yields {
             "Unique; for<?U0> { \
-             substitution [?0 := '?0, ?1 := '!1], \
-             lifetime constraints [InEnvironment { environment: Env([]), goal: '?0 == '!1 }] \
+             substitution [?0 := '?0, ?1 := '!1_0], \
+             lifetime constraints [InEnvironment { environment: Env([]), goal: '?0 == '!1_0 }] \
              }"
         }
     }
@@ -1254,7 +1254,7 @@ fn equality_binder() {
         }
 
         // Check that `'a` (here, `'?0`) is not unified
-        // with `'!1`, because they belong to incompatible
+        // with `'!1_0`, because they belong to incompatible
         // universes.
         goal {
             forall<T> {
@@ -1265,7 +1265,7 @@ fn equality_binder() {
         } yields {
             "Unique; for<?U1> { \
                  substitution [?0 := '?0], \
-                 lifetime constraints [InEnvironment { environment: Env([]), goal: '!2 == '?0 }] \
+                 lifetime constraints [InEnvironment { environment: Env([]), goal: '!2_0 == '?0 }] \
              }"
         }
     }
@@ -2172,8 +2172,8 @@ fn overflow_universe() {
             trait Bar { }
 
             // When asked to solve X: Bar, we will produce a
-            // requirement to solve !1: Bar. And then when asked to
-            // solve that, we'll produce a requirement to solve !2:
+            // requirement to solve !1_0: Bar. And then when asked to
+            // solve that, we'll produce a requirement to solve !1_1:
             // Bar.  And so forth.
             forall<X> { X: Bar if forall<Y> { Y: Bar } }
         }
@@ -2183,7 +2183,7 @@ fn overflow_universe() {
         } yields {
             // The internal universe canonicalization in the on-demand/recursive
             // solver means that when we are asked to solve (e.g.)
-            // `!2: Bar`, we rewrite that to `!1: Bar`, identifying a
+            // `!1_1: Bar`, we rewrite that to `!1_0: Bar`, identifying a
             // cycle.
             "No possible solution"
         }
@@ -2270,9 +2270,9 @@ fn gat_unify_with_implied_wc() {
 //
 // The problem was that we wound up enumerating a goal like
 //
-//     <?0 as SliceExt>::Item = !1
+//     <?0 as SliceExt>::Item = !1_0
 //
-// which meant "find me the types that normalize to `!1`". We had no
+// which meant "find me the types that normalize to `!1_0`". We had no
 // problem finding these types, but after the first such type, we had
 // the only unique answer we would ever find, and we wanted to reach
 // the point where we could say "no more answers", so we kept
@@ -2396,7 +2396,7 @@ fn quantified_types() {
         } yields {
             // Lifetime constraints are unsatisfiable
             "Unique; substitution [], \
-            lifetime constraints [InEnvironment { environment: Env([]), goal: '!2 == '!1 }]"
+            lifetime constraints [InEnvironment { environment: Env([]), goal: '!2_0 == '!1_0 }]"
         }
     }
 }

--- a/src/test/slg.rs
+++ b/src/test/slg.rs
@@ -482,7 +482,7 @@ fn subgoal_cycle_uninhabited() {
                 Answer {
                     subst: Canonical {
                         value: ConstrainedSubst {
-                            subst: [?0 := !1],
+                            subst: [?0 := !1_0],
                             constraints: []
                         },
                         binders: []
@@ -550,7 +550,7 @@ fn basic_region_constraint_from_positive_impl() {
                             constraints: [
                                 InEnvironment {
                                     environment: Env([]),
-                                    goal: '!2 == '!1
+                                    goal: '!1_1 == '!1_0
                                 }
                             ]
                         },


### PR DESCRIPTION
This makes it so that `for<'a, 'b>` or `forall<'a, 'b>` are represented as two lifetimes in the same universe, denoted `!1'0` and `!1'1`. This should not change any semantics.

The end goal is to later make u-canonicalization more powerful by putting parameters bound in the same binder in a canonical order (e.g. order of appearance) so that `forall<T, U> { Goal(T, U) }` and `forall<T, U> { Goal(U, T) }` get u-canonicalized to the same thing, so hopefully that means this change makes sense.

This fixes #147, I think, though there is followup work to be done for types to also use a `UniversalIndex` and improving u-canonicalization.