### PR TITLE
Complete Implementation of LocalImplAllowed(T: Trait)

### DIFF
--- a/chalk-parse/src/ast.rs
+++ b/chalk-parse/src/ast.rs
@@ -243,6 +243,7 @@ pub enum DomainGoal {
     TraitInScope { trait_name: Identifier },
     Derefs { source: Ty, target: Ty },
     IsLocal { ty: Ty },
+    LocalImplAllowed { trait_ref: TraitRef },
 }
 
 #[derive(Clone, PartialEq, Eq, Debug)]

--- a/chalk-parse/src/ast.rs
+++ b/chalk-parse/src/ast.rs
@@ -243,6 +243,8 @@ pub enum DomainGoal {
     TraitInScope { trait_name: Identifier },
     Derefs { source: Ty, target: Ty },
     IsLocal { ty: Ty },
+    IsExternal { ty: Ty },
+    IsDeeplyExternal { ty: Ty },
     LocalImplAllowed { trait_ref: TraitRef },
 }
 

--- a/chalk-parse/src/parser.lalrpop
+++ b/chalk-parse/src/parser.lalrpop
@@ -287,6 +287,8 @@ DomainGoal: DomainGoal = {
     "Derefs" "(" <source:Ty> "," <target:Ty> ")" => DomainGoal::Derefs { source, target },
 
     "IsLocal" "(" <ty:Ty> ")" => DomainGoal::IsLocal { ty },
+    "IsExternal" "(" <ty:Ty> ")" => DomainGoal::IsExternal { ty },
+    "IsDeeplyExternal" "(" <ty:Ty> ")" => DomainGoal::IsDeeplyExternal { ty },
 
     "LocalImplAllowed" "(" <trait_ref:TraitRef<":">> ")" => DomainGoal::LocalImplAllowed { trait_ref },
 };

--- a/chalk-parse/src/parser.lalrpop
+++ b/chalk-parse/src/parser.lalrpop
@@ -287,6 +287,8 @@ DomainGoal: DomainGoal = {
     "Derefs" "(" <source:Ty> "," <target:Ty> ")" => DomainGoal::Derefs { source, target },
 
     "IsLocal" "(" <ty:Ty> ")" => DomainGoal::IsLocal { ty },
+
+    "LocalImplAllowed" "(" <trait_ref:TraitRef<":">> ")" => DomainGoal::LocalImplAllowed { trait_ref },
 };
 
 LeafGoal: LeafGoal = {

--- a/src/fold.rs
+++ b/src/fold.rs
@@ -427,7 +427,8 @@ enum_fold!(WhereClause[] { Implemented(a), ProjectionEq(a) });
 enum_fold!(WellFormed[] { Trait(a), Ty(a) });
 enum_fold!(FromEnv[] { Trait(a), Ty(a) });
 enum_fold!(DomainGoal[] { Holds(a), WellFormed(a), FromEnv(a), Normalize(a), UnselectedNormalize(a),
-                          InScope(a), Derefs(a), IsLocal(a), LocalImplAllowed(a) });
+                          InScope(a), Derefs(a), IsLocal(a), IsExternal(a), IsDeeplyExternal(a),
+                          LocalImplAllowed(a) });
 enum_fold!(LeafGoal[] { EqGoal(a), DomainGoal(a) });
 enum_fold!(Constraint[] { LifetimeEq(a, b) });
 enum_fold!(Goal[] { Quantified(qkind, subgoal), Implies(wc, subgoal), And(g1, g2), Not(g),

--- a/src/ir.rs
+++ b/src/ir.rs
@@ -709,6 +709,29 @@ pub enum DomainGoal {
     /// like `Box<T>`, it is true if `T` is local.
     IsLocal(Ty),
 
+    /// True if a type is *not* considered to have been "defined" by the current crate. This is
+    /// false for a `struct Foo { }` but true for a `extern struct Foo { }`. However, for
+    /// fundamental types like `Box<T>`, it is true if `T` is external.
+    IsExternal(Ty),
+
+    /// True if a type both external and its type parameters are recursively external
+    ///
+    /// More formally, for each non-fundamental struct S<P0..Pn> that is external:
+    /// forall<P0..Pn> {
+    ///     IsDeeplyExternal(S<P0...Pn>) :-
+    ///         IsDeeplyExternal(P0),
+    ///         ...
+    ///         IsDeeplyExternal(Pn)
+    /// }
+    ///
+    /// For each fundamental struct P<P0>,
+    ///
+    /// forall<P0> { IsDeeplyExternal(S<P0>) :- IsDeeplyExternal(P0) }
+    ///
+    /// Note that any of these types can have lifetimes in their parameters too, but we only
+    /// consider type parameters.
+    IsDeeplyExternal(Ty),
+
     /// Used to dictate when trait impls are allowed in the current (local) crate based on the
     /// orphan rules.
     ///

--- a/src/ir.rs
+++ b/src/ir.rs
@@ -596,6 +596,13 @@ pub struct TraitRef {
     crate parameters: Vec<Parameter>,
 }
 
+impl TraitRef {
+    crate fn type_parameters<'a>(&'a self) -> impl Iterator<Item=Ty> + 'a {
+        // This unwrap() is safe because is_ty ensures that we definitely have a Ty
+        self.parameters.iter().filter(|p| p.is_ty()).map(|p| p.clone().ty().unwrap())
+    }
+}
+
 #[derive(Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Debug)]
 pub enum PolarizedTraitRef {
     Positive(TraitRef),

--- a/src/ir.rs
+++ b/src/ir.rs
@@ -453,13 +453,17 @@ pub struct ApplicationTy {
 }
 
 impl ApplicationTy {
-    crate fn first_type_parameter(&self) -> Option<Ty> {
+    crate fn type_parameters<'a>(&'a self) -> impl Iterator<Item=Ty> + 'a {
         // This unwrap() is safe because is_ty ensures that we definitely have a Ty
-        self.parameters.iter().find(|p| p.is_ty()).map(|p| p.clone().ty().unwrap())
+        self.parameters.iter().filter(|p| p.is_ty()).map(|p| p.clone().ty().unwrap())
+    }
+
+    crate fn first_type_parameter(&self) -> Option<Ty> {
+        self.type_parameters().next()
     }
 
     crate fn len_type_parameters(&self) -> usize {
-        self.parameters.iter().filter(|p| p.is_ty()).count()
+        self.type_parameters().count()
     }
 }
 

--- a/src/ir.rs
+++ b/src/ir.rs
@@ -735,7 +735,7 @@ pub enum DomainGoal {
     ///         IsDeeplyExternal(Pn)
     /// }
     ///
-    /// For each fundamental struct P<P0>,
+    /// For each fundamental struct S<P0>,
     ///
     /// forall<P0> { IsDeeplyExternal(S<P0>) :- IsDeeplyExternal(P0) }
     ///

--- a/src/ir/debug.rs
+++ b/src/ir/debug.rs
@@ -213,7 +213,13 @@ impl Debug for DomainGoal {
             DomainGoal::InScope(n) => write!(fmt, "InScope({:?})", n),
             DomainGoal::Derefs(n) => write!(fmt, "Derefs({:?})", n),
             DomainGoal::IsLocal(n) => write!(fmt, "IsLocal({:?})", n),
-            DomainGoal::LocalImplAllowed(n) => write!(fmt, "LocalImplAllowed({:?})", n),
+            DomainGoal::LocalImplAllowed(tr) => write!(
+                fmt,
+                "LocalImplAllowed({:?}: {:?}{:?})",
+                tr.parameters[0],
+                tr.trait_id,
+                Angle(&tr.parameters[1..])
+            ),
         }
     }
 }

--- a/src/ir/debug.rs
+++ b/src/ir/debug.rs
@@ -213,6 +213,8 @@ impl Debug for DomainGoal {
             DomainGoal::InScope(n) => write!(fmt, "InScope({:?})", n),
             DomainGoal::Derefs(n) => write!(fmt, "Derefs({:?})", n),
             DomainGoal::IsLocal(n) => write!(fmt, "IsLocal({:?})", n),
+            DomainGoal::IsExternal(n) => write!(fmt, "IsExternal({:?})", n),
+            DomainGoal::IsDeeplyExternal(n) => write!(fmt, "IsDeeplyExternal({:?})", n),
             DomainGoal::LocalImplAllowed(tr) => write!(
                 fmt,
                 "LocalImplAllowed({:?}: {:?}{:?})",

--- a/src/ir/lowering.rs
+++ b/src/ir/lowering.rs
@@ -524,6 +524,12 @@ impl LowerDomainGoal for DomainGoal {
             DomainGoal::IsLocal { ty } => vec![
                 ir::DomainGoal::IsLocal(ty.lower(env)?)
             ],
+            DomainGoal::IsExternal { ty } => vec![
+                ir::DomainGoal::IsExternal(ty.lower(env)?)
+            ],
+            DomainGoal::IsDeeplyExternal { ty } => vec![
+                ir::DomainGoal::IsDeeplyExternal(ty.lower(env)?)
+            ],
             DomainGoal::LocalImplAllowed { trait_ref } => vec![
                 ir::DomainGoal::LocalImplAllowed(trait_ref.lower(env)?)
             ],

--- a/src/ir/lowering.rs
+++ b/src/ir/lowering.rs
@@ -524,6 +524,9 @@ impl LowerDomainGoal for DomainGoal {
             DomainGoal::IsLocal { ty } => vec![
                 ir::DomainGoal::IsLocal(ty.lower(env)?)
             ],
+            DomainGoal::LocalImplAllowed { trait_ref } => vec![
+                ir::DomainGoal::LocalImplAllowed(trait_ref.lower(env)?)
+            ],
         };
         Ok(goals)
     }

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -452,17 +452,23 @@ impl TraitDatum {
         let mut clauses = vec![wf];
 
         if !self.binders.value.flags.external {
-            let impl_allowed = self.binders.map_ref(|bound_datum| ProgramClauseImplication {
-                consequence: DomainGoal::LocalImplAllowed(bound_datum.self_ty.clone().cast()),
-                conditions: Vec::new(),
-            }).cast();
+            let impl_allowed = self.binders.map_ref(|bound_datum|
+                ProgramClauseImplication {
+                    consequence: DomainGoal::LocalImplAllowed(bound_datum.trait_ref.clone()),
+                    conditions: Vec::new(),
+                }
+            ).cast();
 
             clauses.push(impl_allowed);
         } else {
-            let impl_maybe_allowed = self.binders.map_ref(|bound_datum| ProgramClauseImplication {
-                consequence: DomainGoal::LocalImplAllowed(bound_datum.self_ty.clone().cast()),
-                conditions: Vec::new(),
-            }).cast();
+            let impl_maybe_allowed = self.binders.map_ref(|bound_datum|
+                ProgramClauseImplication {
+                    consequence: DomainGoal::LocalImplAllowed(bound_datum.trait_ref.clone()),
+                    conditions: vec![
+                        DomainGoal::IsLocal(bound_datum.trait_ref.parameters[0].assert_ty_ref().clone()).cast(),
+                    ],
+                }
+            ).cast();
 
             clauses.push(impl_maybe_allowed);
         }

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -523,13 +523,15 @@ impl TraitDatum {
             // that is automatically added to every trait. This is important because otherwise
             // the added program clauses would not have any conditions.
 
-            for i in 0..self.binders.value.trait_ref.parameters.len() {
+            let type_parameters: Vec<_> = self.binders.value.trait_ref.type_parameters().collect();
+
+            for i in 0..type_parameters.len() {
                 let impl_maybe_allowed = self.binders.map_ref(|bound_datum|
                     ProgramClauseImplication {
                         consequence: DomainGoal::LocalImplAllowed(bound_datum.trait_ref.clone()),
-                        conditions:
-                            (0..i).map(|j| DomainGoal::IsDeeplyExternal(bound_datum.trait_ref.parameters[j].assert_ty_ref().clone()).cast())
-                            .chain(iter::once(DomainGoal::IsLocal(bound_datum.trait_ref.parameters[i].assert_ty_ref().clone()).cast()))
+                        conditions: (0..i)
+                            .map(|j| DomainGoal::IsDeeplyExternal(type_parameters[j].clone()).cast())
+                            .chain(iter::once(DomainGoal::IsLocal(type_parameters[i].clone()).cast()))
                             .collect(),
                     }
                 ).cast();

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -158,7 +158,7 @@ impl AssociatedTyValue {
     ///     type IntoIter<'a>: 'a;
     /// }
     /// ```
-    /// 
+    ///
     /// Then for the following impl:
     /// ```notrust
     /// impl<T> Iterable for Vec<T> {
@@ -413,6 +413,19 @@ impl TraitDatum {
         //
         //    forall<Self, T> { (Self: Ord<T>) :- FromEnv(Self: Ord<T>) }
         //    forall<Self, T> { FromEnv(Self: Eq<T>) :- FromEnv(Self: Ord<T>) }
+        //
+        // As specified in the orphan rules, if a trait is not marked `extern`, the current crate
+        // can implement it for any type. To represent that, we generate:
+        //
+        //    // `Ord<T>` would not be `extern` when compiling `std`
+        //    forall<Self, T> { LocalImplAllowed(Self: Ord<T>) }
+        //
+        // For traits that are `extern` (i.e. not in the current crate), the orphan rules specify
+        // that impls are allowed as long as the the type being implemented for is defined in the
+        // current crate. This is represented as follows:
+        //
+        //    // for `extern trait Ord<T> where Self: Eq<T> { ... }`
+        //    forall<Self, T> { LocalImplAllowed(Self: Ord<T>) :- IsLocal(Self) }
 
         let trait_ref = self.binders.value.trait_ref.clone();
 
@@ -437,6 +450,23 @@ impl TraitDatum {
         }).cast();
 
         let mut clauses = vec![wf];
+
+        if !self.binders.value.flags.external {
+            let impl_allowed = self.binders.map_ref(|bound_datum| ProgramClauseImplication {
+                consequence: DomainGoal::LocalImplAllowed(bound_datum.self_ty.clone().cast()),
+                conditions: Vec::new(),
+            }).cast();
+
+            clauses.push(impl_allowed);
+        } else {
+            let impl_maybe_allowed = self.binders.map_ref(|bound_datum| ProgramClauseImplication {
+                consequence: DomainGoal::LocalImplAllowed(bound_datum.self_ty.clone().cast()),
+                conditions: Vec::new(),
+            }).cast();
+
+            clauses.push(impl_maybe_allowed);
+        }
+
         let condition = DomainGoal::FromEnv(FromEnv::Trait(trait_ref.clone()));
 
         for wc in self.binders

--- a/src/solve/test.rs
+++ b/src/solve/test.rs
@@ -2489,8 +2489,12 @@ fn local_and_external_types() {
         }
 
         goal { IsLocal(External) } yields { "No possible solution" }
+        goal { IsExternal(External) } yields { "Unique" }
+        goal { IsDeeplyExternal(External) } yields { "Unique" }
 
         goal { IsLocal(Internal) } yields { "Unique" }
+        goal { IsExternal(Internal) } yields { "No possible solution" }
+        goal { IsDeeplyExternal(Internal) } yields { "No possible solution" }
     }
 
     test! {
@@ -2498,11 +2502,25 @@ fn local_and_external_types() {
             trait Clone { }
             extern struct External<T> where T: Clone { }
             struct Internal<T> where T: Clone { }
+
+            extern struct External2 { }
+            struct Internal2 { }
         }
 
         goal { forall<T> { IsLocal(External<T>) } } yields { "No possible solution" }
+        goal { forall<T> { IsExternal(External<T>) } } yields { "Unique" }
 
         goal { forall<T> { IsLocal(Internal<T>) } } yields { "Unique" }
+        goal { forall<T> { IsExternal(Internal<T>) } } yields { "No possible solution" }
+
+        // Not true for all T
+        goal { forall<T> { IsDeeplyExternal(External<T>) } } yields { "No possible solution" }
+
+        // Must be recursively external
+        goal { IsDeeplyExternal(External<External<External<External2>>>) } yields { "Unique" }
+        goal { IsDeeplyExternal(Internal<External<External2>>) } yields { "No possible solution" }
+        goal { IsDeeplyExternal(External<Internal<External<External2>>>) } yields { "No possible solution" }
+        goal { IsDeeplyExternal(External<External<External<Internal2>>>) } yields { "No possible solution" }
     }
 }
 

--- a/src/solve/test.rs
+++ b/src/solve/test.rs
@@ -2614,3 +2614,35 @@ fn fundamental_types() {
         goal { IsLocal(Box<Internal>) } yields { "Unique" }
     }
 }
+
+#[test]
+fn impl_allowed_for_traits() {
+    test! {
+        program {
+            extern trait ExternalTrait { }
+            trait InternalTrait { }
+
+            extern struct External { }
+            struct Internal { }
+        }
+
+        goal { forall<T> { LocalImplAllowed(T: ExternalTrait) } } yields { "No possible solution" }
+
+        goal { forall<T> { LocalImplAllowed(T: InternalTrait) } } yields { "Unique" }
+    }
+
+    test! {
+        program {
+            trait Clone { }
+            extern trait ExternalTrait<T> where T: Clone { }
+            trait InternalTrait<T> where T: Clone { }
+
+            extern struct External { }
+            struct Internal { }
+        }
+
+        goal { forall<T, U> { LocalImplAllowed(T: ExternalTrait<U>) } } yields { "No possible solution" }
+
+        goal { forall<T, U> { LocalImplAllowed(T: InternalTrait<U>) } } yields { "Unique" }
+    }
+}

--- a/src/solve/test.rs
+++ b/src/solve/test.rs
@@ -2627,8 +2627,12 @@ fn impl_allowed_for_traits() {
         }
 
         goal { forall<T> { LocalImplAllowed(T: ExternalTrait) } } yields { "No possible solution" }
+        goal { LocalImplAllowed(Internal: ExternalTrait) } yields { "Unique" }
+        goal { LocalImplAllowed(External: ExternalTrait) } yields { "No possible solution" }
 
         goal { forall<T> { LocalImplAllowed(T: InternalTrait) } } yields { "Unique" }
+        goal { LocalImplAllowed(Internal: InternalTrait) } yields { "Unique" }
+        goal { LocalImplAllowed(External: InternalTrait) } yields { "Unique" }
     }
 
     test! {
@@ -2642,7 +2646,11 @@ fn impl_allowed_for_traits() {
         }
 
         goal { forall<T, U> { LocalImplAllowed(T: ExternalTrait<U>) } } yields { "No possible solution" }
+        goal { forall<T> { LocalImplAllowed(Internal: ExternalTrait<T>) } } yields { "Unique" }
+        goal { forall<T> { LocalImplAllowed(External: ExternalTrait<T>) } } yields { "No possible solution" }
 
         goal { forall<T, U> { LocalImplAllowed(T: InternalTrait<U>) } } yields { "Unique" }
+        goal { forall<T> { LocalImplAllowed(Internal: InternalTrait<T>) } } yields { "Unique" }
+        goal { forall<T> { LocalImplAllowed(External: InternalTrait<T>) } } yields { "Unique" }
     }
 }

--- a/src/solve/test.rs
+++ b/src/solve/test.rs
@@ -2643,12 +2643,18 @@ fn impl_allowed_for_traits() {
 
             extern struct External { }
             struct Internal { }
+
+            //FIXME(sunjay): Delete this line once IsDeeplyExternal is implemented
+            forall<> { IsDeeplyExternal(External) }
         }
 
         goal { forall<T, U> { LocalImplAllowed(T: ExternalTrait<U>) } } yields { "No possible solution" }
+        // Types after the first local type do not matter
         goal { forall<T> { LocalImplAllowed(Internal: ExternalTrait<T>) } } yields { "Unique" }
-        goal { forall<T> { LocalImplAllowed(External: ExternalTrait<T>) } } yields { "No possible solution" }
+        goal { LocalImplAllowed(External: ExternalTrait<External>) } yields { "No possible solution" }
+        goal { LocalImplAllowed(External: ExternalTrait<Internal>) } yields { "Unique" }
 
+        // If the trait itself is local the types implemented for do not matter
         goal { forall<T, U> { LocalImplAllowed(T: InternalTrait<U>) } } yields { "Unique" }
         goal { forall<T> { LocalImplAllowed(Internal: InternalTrait<T>) } } yields { "Unique" }
         goal { forall<T> { LocalImplAllowed(External: InternalTrait<T>) } } yields { "Unique" }

--- a/src/zip.rs
+++ b/src/zip.rs
@@ -228,6 +228,8 @@ enum_zip!(DomainGoal {
     InScope,
     Derefs,
     IsLocal,
+    IsExternal,
+    IsDeeplyExternal,
     LocalImplAllowed
 });
 enum_zip!(LeafGoal { DomainGoal, EqGoal });


### PR DESCRIPTION
If it makes it easier to review, I can potentially split this PR up into smaller PRs. That being said, I think I have provided enough background in the rest of this description to give you enough context to be able to review all of this with no issues.

(If any part of what I describe isn't totally accurate, I would love your feedback on it. :smile:)

This PR adds `LocalImplAllowed(T: Trait)`. This goal will be used to implement the "orphan check". Basically, if a type `Foo` satisifies `LocalImplAllowed(Foo: Trait)`, it is allowed by the orphan rules to implement `Trait`. Niko and I are working on [another part](https://gist.github.com/nikomatsakis/d82d18fb08453074457c906f8198e3e3) ([context](http://aturon.github.io/blog/2017/04/24/negative-chalk/)) of this which will be incorporated into the overlap check to ensure that impls can't violate the orphan rules.

For a local trait, `LocalImplAllowed` is pretty simple. It allows you to implement that trait for any type since you were the one who defined it.

```rust
forall<P0, P1..Pn> { LocalImplAllowed(P0: LocalTrait<P1..Pn>) }
```

For an external trait, the rules are a bit more complicated. The orphan rules dictate that an implementation `ExternTrait<P1..Pn> for P0` is allowed if all of the following is met:

1. There is some parameter `Pi` that is a local type (according to `IsLocal` and considering fundamental types)
2. Within `Pi`, all type parameters on the impl are covered by this local type -- This rule probably isn't that relevant anymore because tuples aren't fundamental
3. Each prior parameter `Pj` where `j < i` is a **deeply external type** that does not contain any of the parameters `P0..Pn`

`LocalImplAllowed` manages to check for all of this using a new predicate `IsDeeplyExternal`.

## Example

Let's say you had:

```rust
extern trait Foo<T, U, V> where Self: Eq<T> { ... }
```

This would generate the following program clauses:

```rust
forall<Self, T, U, V> {
  LocalImplAllowed(Self: Foo<T, U, V>) :- IsLocal(Self)
}
forall<Self, T, U, V> {
  LocalImplAllowed(Self: Foo<T, U, V>) :-
      IsDeeplyExternal(Self),
      IsLocal(T)
}
forall<Self, T, U, V> {
  LocalImplAllowed(Self: Foo<T, U, V>) :-
      IsDeeplyExternal(Self),
      IsDeeplyExternal(T),
      IsLocal(U)
}
forall<Self, T, U, V> {
  LocalImplAllowed(Self: Foo<T, U, V>) :-
      IsDeeplyExternal(Self),
      IsDeeplyExternal(T),
      IsDeeplyExternal(U),
      IsLocal(V)
}
```
We generate every possible case for each `i` from `0` to `n`. This correctly models the orphan rules as defined above.

`IsDeeplyExternal` is pretty simple. Given a type `S<T1..Tn>`, we generate:

```rust
forall<T1..Tn> { IsDeeplyExternal(S<T1..Tn>) :- IsDeeplyExternal(T1), ..., IsDeeplyExternal(Tn) }
```

This encapsulates the "does not contain any of the parameters `P0..Pn`" part of the rules because type parameters are neither local nor external. If we had `impl<T> ExternalTrait<LocalType> for T`, we would not be able to prove `IsLocal(T)` or `IsDeeplyExternal(T)`.

The reason this PR is rather large is because it contains:

- [x] the implementation of `IsDeeplyExternal`
    - [x] for normal types
        - [x] code documentation
        - [x] tests
    - [x] for fundamental types
        - [x] code documentation
        - [x] tests
- [x] the implementation of `LocalImplAllowed`
    - [x] for normal types
        - [x] code documentation
        - [x] tests
    - [x] for fundamental types
        - [x] code documentation
        - [x] tests