### PR TITLE
Refactoring external and fundamental struct flags into a single StructType enum

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,4 +1,4 @@
-#![allow(bare_trait_object)] // FIXME -- error-chain uses old-style trait objects
+#![allow(bare_trait_objects)] // FIXME -- error-chain uses old-style trait objects
 
 use chalk_parse::{self, ast};
 use ir;

--- a/src/ir.rs
+++ b/src/ir.rs
@@ -239,13 +239,14 @@ pub struct StructDatumBound {
     crate self_ty: ApplicationTy,
     crate fields: Vec<Ty>,
     crate where_clauses: Vec<QuantifiedWhereClause>,
-    crate flags: StructFlags,
+    crate struct_type: StructType,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
-pub struct StructFlags {
-    crate external: bool,
-    crate fundamental: bool,
+pub enum StructType {
+    External,
+    Fundamental,
+    Local,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]

--- a/src/ir/lowering.rs
+++ b/src/ir/lowering.rs
@@ -592,9 +592,12 @@ impl LowerStructDefn for StructDefn {
                 self_ty,
                 fields: fields?,
                 where_clauses,
-                flags: ir::StructFlags {
-                    external: self.flags.external,
-                    fundamental: self.flags.fundamental,
+                struct_type: match (self.flags.external, self.flags.fundamental) {
+                    // A local struct is local regardless of fundamental
+                    (false, _) => ir::StructType::Local,
+                    // An external struct can be fundamental or not
+                    (true, false) => ir::StructType::External,
+                    (true, true) => ir::StructType::Fundamental,
                 },
             })
         })?;


### PR DESCRIPTION
The insight was that structs aren't really external or not, they are either local, fundamental, or external. The parsing and AST are left the same, only the IR is changed. This does not affect the behaviour of any of the code at all, only the representation is slightly refactored.