### PR TITLE
Performing the Orphan Check on all local impls

### DIFF
--- a/chalk-parse/src/ast.rs
+++ b/chalk-parse/src/ast.rs
@@ -148,6 +148,13 @@ pub struct Impl {
     pub trait_ref: PolarizedTraitRef,
     pub where_clauses: Vec<QuantifiedWhereClause>,
     pub assoc_ty_values: Vec<AssocTyValue>,
+    pub impl_type: ImplType,
+}
+
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub enum ImplType {
+    Local,
+    External,
 }
 
 #[derive(Clone, PartialEq, Eq, Debug)]

--- a/chalk-parse/src/parser.lalrpop
+++ b/chalk-parse/src/parser.lalrpop
@@ -115,7 +115,7 @@ ProjectionEqBound: ProjectionEqBound = {
 };
 
 Impl: Impl = {
-    "impl" <p:Angle<ParameterKind>> <mark:"!"?> <t:Id> <a:Angle<Parameter>> "for" <s:Ty>
+    <external:ExternalKeyword?> "impl" <p:Angle<ParameterKind>> <mark:"!"?> <t:Id> <a:Angle<Parameter>> "for" <s:Ty>
         <w:QuantifiedWhereClauses> "{" <assoc:AssocTyValue*> "}" =>
     {
         let mut args = vec![Parameter::Ty(s)];
@@ -128,6 +128,7 @@ Impl: Impl = {
             }),
             where_clauses: w,
             assoc_ty_values: assoc,
+            impl_type: external.map(|_| ImplType::External).unwrap_or(ImplType::Local),
         }
     },
 };

--- a/chalk-parse/src/parser.lalrpop
+++ b/chalk-parse/src/parser.lalrpop
@@ -57,7 +57,7 @@ StructDefn: StructDefn = {
 };
 
 TraitDefn: TraitDefn = {
-    <external:ExternalKeyword?> <auto:AutoKeyword?> <marker:MarkerKeyword?> <deref:DerefLangItem?> "trait" <n:Id><p:Angle<ParameterKind>>
+    <auto:AutoKeyword?> <marker:MarkerKeyword?> <deref:DerefLangItem?> <external:ExternalKeyword?> "trait" <n:Id><p:Angle<ParameterKind>>
         <w:QuantifiedWhereClauses> "{" <a:AssocTyDefn*> "}" => TraitDefn
     {
         name: n,

--- a/src/coherence.rs
+++ b/src/coherence.rs
@@ -6,6 +6,7 @@ use solve::SolverChoice;
 use std::sync::Arc;
 
 mod solve;
+mod orphan;
 mod test;
 
 impl Program {

--- a/src/coherence/orphan.rs
+++ b/src/coherence/orphan.rs
@@ -1,0 +1,61 @@
+use std::sync::Arc;
+
+use errors::*;
+use ir::*;
+use cast::*;
+use solve::SolverChoice;
+
+struct OrphanSolver {
+    env: Arc<ProgramEnvironment>,
+    solver_choice: SolverChoice,
+}
+
+impl Program {
+    crate fn perform_orphan_check(&self, solver_choice: SolverChoice) -> Result<()> {
+        let solver = OrphanSolver {
+            env: Arc::new(self.environment()),
+            solver_choice,
+        };
+
+        let local_impls = self.impl_data
+            .values()
+            // Only keep local impls (i.e. impls in the current crate)
+            .filter(|impl_datum| impl_datum.binders.value.impl_type == ImplType::Local);
+
+        for impl_datum in local_impls {
+            if !solver.orphan_check(impl_datum) {
+                let trait_id = impl_datum.binders.value.trait_ref.trait_ref().trait_id;
+                let trait_id = self.type_kinds.get(&trait_id).unwrap().name;
+                return Err(Error::from_kind(ErrorKind::FailedOrphanCheck(trait_id)));
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl OrphanSolver {
+    // Test if a local impl violates the orphan rules.
+    //
+    // For `impl<T> Trait for MyType<T>` we generate:
+    //
+    //     forall<T> { LocalImplAllowed(MyType<T>: Trait) }
+    //
+    // This must be provable in order to pass the orphan check.
+    fn orphan_check(&self, impl_datum: &ImplDatum) -> bool {
+        debug_heading!("orphan_check(impl={:#?})", impl_datum);
+
+        let impl_allowed: Goal = impl_datum.binders.map_ref(|bound_impl| {
+            // Ignoring the polarization of the impl's polarized trait ref
+            DomainGoal::LocalImplAllowed(bound_impl.trait_ref.trait_ref().clone())
+        }).cast();
+
+        let canonical_goal = &impl_allowed.into_closed_goal();
+        let result = self.solver_choice
+            .solve_root_goal(&self.env, canonical_goal)
+            .unwrap()
+            .is_some();
+        debug!("overlaps: result = {:?}", result);
+        result
+    }
+}

--- a/src/coherence/test.rs
+++ b/src/coherence/test.rs
@@ -310,8 +310,11 @@ fn orphan_check() {
 
             struct TheType { }
 
+            // These impls should be fine because they contain the local type
             impl TheTrait<TheType> for isize { }
             impl TheTrait<isize> for TheType { }
+
+            // This impl should fail because it contains only external type
             impl TheTrait<usize> for isize { }
         } error_msg {
             "impl for trait \"TheTrait\" violates the orphan rules"

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -55,5 +55,10 @@ error_chain! {
             description("Duplicate lang item")
                 display("Duplicate lang item `{:?}`", item)
         }
+
+        FailedOrphanCheck(trait_id: ir::Identifier) {
+            description("impl violates the orphan rules")
+                display("impl for trait {:?} violates the orphan rules", trait_id)
+        }
     }
 }

--- a/src/ir.rs
+++ b/src/ir.rs
@@ -216,6 +216,13 @@ pub struct ImplDatumBound {
     crate where_clauses: Vec<QuantifiedWhereClause>,
     crate associated_ty_values: Vec<AssociatedTyValue>,
     crate specialization_priority: usize,
+    crate impl_type: ImplType,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub enum ImplType {
+    Local,
+    External,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]

--- a/src/ir/lowering.rs
+++ b/src/ir/lowering.rs
@@ -940,6 +940,10 @@ impl LowerImpl for Impl {
                 where_clauses,
                 associated_ty_values,
                 specialization_priority: 0,
+                impl_type: match self.impl_type {
+                    ImplType::Local => ir::ImplType::Local,
+                    ImplType::External => ir::ImplType::External,
+                },
             })
         })?;
 

--- a/src/ir/lowering.rs
+++ b/src/ir/lowering.rs
@@ -233,6 +233,7 @@ impl LowerProgram for Program {
         program.add_default_impls();
         program.record_specialization_priorities(solver_choice)?;
         program.verify_well_formedness(solver_choice)?;
+        program.perform_orphan_check(solver_choice)?;
         Ok(program)
     }
 }

--- a/src/ir/lowering/test.rs
+++ b/src/ir/lowering/test.rs
@@ -215,7 +215,8 @@ fn atc_accounting() {
                 }
             }
         ],
-        specialization_priority: 0
+        specialization_priority: 0,
+        impl_type: Local
     }
 }"#
         );


### PR DESCRIPTION
This PR adds the orphan check during lowering. This checks that each local impl satisfies the orphan rules via the `LocalImplAllowed` goal.

If you have:

```rust
impl<T> Trait for MyType<T>
```

We generate:

```rust
forall<T> { LocalImplAllowed(MyType<T>: Trait) }
```

If that is not provable, your impl violates the orphan rules.

---

This PR adds:

- [x] The ability to mark an impl `extern` to allow us to differentiate between local and external impls (not actually used in tests yet, see below)
    - [x] parsing => AST
    - [x] lowering => IR
- [x] A new module for the orphan check similar to the modules we have for overlap/disjoint, wf, etc.
    - [x] call to the method this module adds during the lowering process
- [x] Tests for coherence violations (Looks like `LocalImplAllowed` works!)

The tests are largely taken/adapted from rustc's coherence tests. I am not totally satisfied with their coverage, so I will probably go add more tests tomorrow. In particular, I want to add some tests with successful outcomes so that the `extern impl` syntax I added can actually get used. This syntax, while not used just yet, is definitely necessary for lowering real Rust programs.