### PR TITLE
Rename IsExternal to IsUpstream and extern keyword to #[upstream]

### DIFF
--- a/chalk-parse/src/ast.rs
+++ b/chalk-parse/src/ast.rs
@@ -37,7 +37,7 @@ pub struct StructDefn {
 
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub struct StructFlags {
-    pub external: bool,
+    pub upstream: bool,
     pub fundamental: bool,
 }
 
@@ -54,7 +54,7 @@ pub struct TraitDefn {
 pub struct TraitFlags {
     pub auto: bool,
     pub marker: bool,
-    pub external: bool,
+    pub upstream: bool,
     pub deref: bool,
 }
 
@@ -256,7 +256,7 @@ pub enum DomainGoal {
     TraitInScope { trait_name: Identifier },
     Derefs { source: Ty, target: Ty },
     IsLocal { ty: Ty },
-    IsExternal { ty: Ty },
+    IsUpstream { ty: Ty },
     IsDeeplyExternal { ty: Ty },
     LocalImplAllowed { trait_ref: TraitRef },
 }

--- a/chalk-parse/src/parser.lalrpop
+++ b/chalk-parse/src/parser.lalrpop
@@ -36,14 +36,14 @@ Goal1: Box<Goal> = {
     "(" <Goal> ")",
 };
 
-ExternalKeyword: () = "extern";
+UpstreamKeyword: () = "#" "[" "upstream" "]";
 AutoKeyword: () = "#" "[" "auto" "]";
 MarkerKeyword: () = "#" "[" "marker" "]";
 DerefLangItem: () = "#" "[" "lang_deref" "]";
 FundamentalKeyword: () = "#" "[" "fundamental" "]";
 
 StructDefn: StructDefn = {
-    <fundamental:FundamentalKeyword?> <external:ExternalKeyword?> "struct" <n:Id><p:Angle<ParameterKind>>
+    <upstream:UpstreamKeyword?> <fundamental:FundamentalKeyword?> "struct" <n:Id><p:Angle<ParameterKind>>
         <w:QuantifiedWhereClauses> "{" <f:Fields> "}" => StructDefn
     {
         name: n,
@@ -51,14 +51,14 @@ StructDefn: StructDefn = {
         where_clauses: w,
         fields: f,
         flags: StructFlags {
-            external: external.is_some(),
+            upstream: upstream.is_some(),
             fundamental: fundamental.is_some(),
         },
     }
 };
 
 TraitDefn: TraitDefn = {
-    <auto:AutoKeyword?> <marker:MarkerKeyword?> <deref:DerefLangItem?> <external:ExternalKeyword?> "trait" <n:Id><p:Angle<ParameterKind>>
+    <auto:AutoKeyword?> <marker:MarkerKeyword?> <upstream:UpstreamKeyword?> <deref:DerefLangItem?> "trait" <n:Id><p:Angle<ParameterKind>>
         <w:QuantifiedWhereClauses> "{" <a:AssocTyDefn*> "}" => TraitDefn
     {
         name: n,
@@ -68,7 +68,7 @@ TraitDefn: TraitDefn = {
         flags: TraitFlags {
             auto: auto.is_some(),
             marker: marker.is_some(),
-            external: external.is_some(),
+            upstream: upstream.is_some(),
             deref: deref.is_some(),
         },
     }
@@ -128,7 +128,7 @@ QuantifiedInlineBound: QuantifiedInlineBound = {
 };
 
 Impl: Impl = {
-    <external:ExternalKeyword?> "impl" <p:Angle<ParameterKind>> <mark:"!"?> <t:Id> <a:Angle<Parameter>> "for" <s:Ty>
+    <external:UpstreamKeyword?> "impl" <p:Angle<ParameterKind>> <mark:"!"?> <t:Id> <a:Angle<Parameter>> "for" <s:Ty>
         <w:QuantifiedWhereClauses> "{" <assoc:AssocTyValue*> "}" =>
     {
         let mut args = vec![Parameter::Ty(s)];
@@ -301,7 +301,7 @@ DomainGoal: DomainGoal = {
     "Derefs" "(" <source:Ty> "," <target:Ty> ")" => DomainGoal::Derefs { source, target },
 
     "IsLocal" "(" <ty:Ty> ")" => DomainGoal::IsLocal { ty },
-    "IsExternal" "(" <ty:Ty> ")" => DomainGoal::IsExternal { ty },
+    "IsUpstream" "(" <ty:Ty> ")" => DomainGoal::IsUpstream { ty },
     "IsDeeplyExternal" "(" <ty:Ty> ")" => DomainGoal::IsDeeplyExternal { ty },
 
     "LocalImplAllowed" "(" <trait_ref:TraitRef<":">> ")" => DomainGoal::LocalImplAllowed { trait_ref },

--- a/src/coherence/test.rs
+++ b/src/coherence/test.rs
@@ -233,8 +233,8 @@ fn orphan_check() {
 
     lowering_error! {
         program {
-            extern trait Foo { }
-            extern struct Bar { }
+            #[upstream] trait Foo { }
+            #[upstream] struct Bar { }
 
             impl Foo for Bar { }
         } error_msg {
@@ -244,7 +244,7 @@ fn orphan_check() {
 
     lowering_error! {
         program {
-            extern trait Foo { }
+            #[upstream] trait Foo { }
 
             impl<T> Foo for T { }
         } error_msg {
@@ -254,7 +254,7 @@ fn orphan_check() {
 
     lowering_error! {
         program {
-            extern trait Foo<T> { }
+            #[upstream] trait Foo<T> { }
             struct Bar { }
 
             impl<T> Foo<Bar> for T { }
@@ -269,8 +269,8 @@ fn orphan_check() {
     // with RFC 1023 and this became illegal.
     lowering_error! {
         program {
-            extern trait Remote { }
-            extern struct Pair<T, U> { }
+            #[upstream] trait Remote { }
+            #[upstream] struct Pair<T, U> { }
             struct Cover<T> { }
 
             impl<T> Remote for Pair<T, Cover<T>> { }
@@ -280,8 +280,8 @@ fn orphan_check() {
     }
     lowering_error! {
         program {
-            extern trait Remote { }
-            extern struct Pair<T, U> { }
+            #[upstream] trait Remote { }
+            #[upstream] struct Pair<T, U> { }
             struct Cover<T> { }
 
             impl<T> Remote for Pair<Cover<T>, T> { }
@@ -291,8 +291,8 @@ fn orphan_check() {
     }
     lowering_error! {
         program {
-            extern trait Remote { }
-            extern struct Pair<T, U> { }
+            #[upstream] trait Remote { }
+            #[upstream] struct Pair<T, U> { }
             struct Cover<T> { }
 
             impl<T, U> Remote for Pair<Cover<T>, U> { }
@@ -303,10 +303,10 @@ fn orphan_check() {
 
     lowering_error! {
         program {
-            #[auto] extern trait Send { }
-            extern trait TheTrait<T> { }
-            extern struct isize { }
-            extern struct usize { }
+            #[auto] #[upstream] trait Send { }
+            #[upstream] trait TheTrait<T> { }
+            #[upstream] struct isize { }
+            #[upstream] struct usize { }
 
             struct TheType { }
 
@@ -314,7 +314,7 @@ fn orphan_check() {
             impl TheTrait<TheType> for isize { }
             impl TheTrait<isize> for TheType { }
 
-            // This impl should fail because it contains only external type
+            // This impl should fail because it contains only upstream type
             impl TheTrait<usize> for isize { }
         } error_msg {
             "impl for trait \"TheTrait\" violates the orphan rules"
@@ -323,9 +323,9 @@ fn orphan_check() {
 
     lowering_error! {
         program {
-            #[auto] extern trait Send { }
-            extern struct Vec<T> { }
-            extern struct isize { }
+            #[auto] #[upstream] trait Send { }
+            #[upstream] struct Vec<T> { }
+            #[upstream] struct isize { }
 
             impl !Send for Vec<isize> { }
         } error_msg {
@@ -335,8 +335,8 @@ fn orphan_check() {
 
     lowering_error! {
         program {
-            extern trait Remote { }
-            extern struct Pair<T, U> { }
+            #[upstream] trait Remote { }
+            #[upstream] struct Pair<T, U> { }
 
             struct Foo { }
 
@@ -348,9 +348,9 @@ fn orphan_check() {
 
     lowering_error! {
         program {
-            extern trait Remote1<T> { }
-            extern struct Pair<T, U> { }
-            extern struct i32 { }
+            #[upstream] trait Remote1<T> { }
+            #[upstream] struct Pair<T, U> { }
+            #[upstream] struct i32 { }
 
             struct Local<T> { }
 
@@ -362,8 +362,8 @@ fn orphan_check() {
 
     lowering_error! {
         program {
-            extern trait Remote { }
-            extern struct Pair<T, U> { }
+            #[upstream] trait Remote { }
+            #[upstream] struct Pair<T, U> { }
 
             struct Local<T> { }
 
@@ -375,8 +375,8 @@ fn orphan_check() {
 
     lowering_error! {
         program {
-            extern trait Remote { }
-            extern struct Vec<T> { }
+            #[upstream] trait Remote { }
+            #[upstream] struct Vec<T> { }
 
             struct Local { }
 
@@ -388,8 +388,8 @@ fn orphan_check() {
 
     lowering_error! {
         program {
-            extern trait Remote { }
-            extern struct Vec<T> { }
+            #[upstream] trait Remote { }
+            #[upstream] struct Vec<T> { }
 
             struct Local<T> { }
 

--- a/src/fold.rs
+++ b/src/fold.rs
@@ -427,7 +427,7 @@ enum_fold!(WhereClause[] { Implemented(a), ProjectionEq(a) });
 enum_fold!(WellFormed[] { Trait(a), Ty(a) });
 enum_fold!(FromEnv[] { Trait(a), Ty(a) });
 enum_fold!(DomainGoal[] { Holds(a), WellFormed(a), FromEnv(a), Normalize(a), UnselectedNormalize(a),
-                          InScope(a), Derefs(a), IsLocal(a), IsExternal(a), IsDeeplyExternal(a),
+                          InScope(a), Derefs(a), IsLocal(a), IsUpstream(a), IsDeeplyExternal(a),
                           LocalImplAllowed(a), Compatible(a), DownstreamType(a) });
 enum_fold!(LeafGoal[] { EqGoal(a), DomainGoal(a) });
 enum_fold!(Constraint[] { LifetimeEq(a, b) });

--- a/src/ir.rs
+++ b/src/ir.rs
@@ -251,7 +251,7 @@ pub struct StructDatumBound {
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct StructFlags {
-    crate external: bool,
+    crate upstream: bool,
     crate fundamental: bool,
 }
 
@@ -271,7 +271,7 @@ pub struct TraitDatumBound {
 pub struct TraitFlags {
     crate auto: bool,
     crate marker: bool,
-    crate external: bool,
+    crate upstream: bool,
     pub deref: bool,
 }
 
@@ -737,14 +737,14 @@ pub enum DomainGoal {
     Derefs(Derefs),
 
     /// True if a type is considered to have been "defined" by the current crate. This is true for
-    /// a `struct Foo { }` but false for a `extern struct Foo { }`. However, for fundamental types
+    /// a `struct Foo { }` but false for a `#[upstream] struct Foo { }`. However, for fundamental types
     /// like `Box<T>`, it is true if `T` is local.
     IsLocal(Ty),
 
     /// True if a type is *not* considered to have been "defined" by the current crate. This is
-    /// false for a `struct Foo { }` but true for a `extern struct Foo { }`. However, for
-    /// fundamental types like `Box<T>`, it is true if `T` is external.
-    IsExternal(Ty),
+    /// false for a `struct Foo { }` but true for a `#[upstream] struct Foo { }`. However, for
+    /// fundamental types like `Box<T>`, it is true if `T` is upstream.
+    IsUpstream(Ty),
 
     /// True if a type both external and its type parameters are recursively external
     ///

--- a/src/ir/debug.rs
+++ b/src/ir/debug.rs
@@ -213,7 +213,7 @@ impl Debug for DomainGoal {
             DomainGoal::InScope(n) => write!(fmt, "InScope({:?})", n),
             DomainGoal::Derefs(n) => write!(fmt, "Derefs({:?})", n),
             DomainGoal::IsLocal(n) => write!(fmt, "IsLocal({:?})", n),
-            DomainGoal::IsExternal(n) => write!(fmt, "IsExternal({:?})", n),
+            DomainGoal::IsUpstream(n) => write!(fmt, "IsUpstream({:?})", n),
             DomainGoal::IsDeeplyExternal(n) => write!(fmt, "IsDeeplyExternal({:?})", n),
             DomainGoal::LocalImplAllowed(tr) => write!(
                 fmt,

--- a/src/ir/lowering.rs
+++ b/src/ir/lowering.rs
@@ -521,8 +521,8 @@ impl LowerDomainGoal for DomainGoal {
             DomainGoal::IsLocal { ty } => vec![
                 ir::DomainGoal::IsLocal(ty.lower(env)?)
             ],
-            DomainGoal::IsExternal { ty } => vec![
-                ir::DomainGoal::IsExternal(ty.lower(env)?)
+            DomainGoal::IsUpstream { ty } => vec![
+                ir::DomainGoal::IsUpstream(ty.lower(env)?)
             ],
             DomainGoal::IsDeeplyExternal { ty } => vec![
                 ir::DomainGoal::IsDeeplyExternal(ty.lower(env)?)
@@ -590,7 +590,7 @@ impl LowerStructDefn for StructDefn {
                 fields: fields?,
                 where_clauses,
                 flags: ir::StructFlags {
-                    external: self.flags.external,
+                    upstream: self.flags.upstream,
                     fundamental: self.flags.fundamental,
                 },
             })
@@ -1049,7 +1049,7 @@ impl LowerTrait for TraitDefn {
                 flags: ir::TraitFlags {
                     auto: self.flags.auto,
                     marker: self.flags.marker,
-                    external: self.flags.external,
+                    upstream: self.flags.upstream,
                     deref: self.flags.deref,
                 },
             })

--- a/src/ir/lowering/test.rs
+++ b/src/ir/lowering/test.rs
@@ -420,11 +420,11 @@ fn duplicate_parameters() {
 }
 
 #[test]
-fn external_items() {
+fn upstream_items() {
     lowering_success! {
         program {
-            extern trait Send { }
-            extern struct Vec<T> { }
+            #[upstream] trait Send { }
+            #[upstream] struct Vec<T> { }
         }
     }
 }

--- a/src/zip.rs
+++ b/src/zip.rs
@@ -234,7 +234,7 @@ enum_zip!(DomainGoal {
     InScope,
     Derefs,
     IsLocal,
-    IsExternal,
+    IsUpstream,
     IsDeeplyExternal,
     LocalImplAllowed,
     Compatible,


### PR DESCRIPTION
We are changing the terminology of chalk to use "upstream" instead of "external". This change is particularly useful in the upcoming coherence implementation as it precisely describes the structs and traits we want to be talking about.

This PR does not change `IsDeeplyExternal` as that is going to be removed in #153 anyway once I get around to it.

This is just a renaming, so no functionality is changed whatsoever. Hopefully that will make it very easy to review.