### PR TITLE
Implementing Compatible Modality Syntax

### DIFF
--- a/chalk-parse/src/ast.rs
+++ b/chalk-parse/src/ast.rs
@@ -284,6 +284,9 @@ pub enum Goal {
     And(Box<Goal>, Box<Goal>),
     Not(Box<Goal>),
 
+    /// The `compatible { G }` syntax
+    Compatible(Box<Goal>),
+
     // Additional kinds of goals:
     Leaf(LeafGoal),
 }

--- a/chalk-parse/src/parser.lalrpop
+++ b/chalk-parse/src/parser.lalrpop
@@ -31,6 +31,7 @@ Goal1: Box<Goal> = {
     "exists" "<" <p:Comma<ParameterKind>> ">" "{" <g:Goal> "}" => Box::new(Goal::Exists(p, g)),
     "if" "(" <h:SemiColon<InlineClause>> ")" "{" <g:Goal> "}" => Box::new(Goal::Implies(h, g)),
     "not" "{" <g:Goal> "}" => Box::new(Goal::Not(g)),
+    "compatible" "{" <g:Goal> "}" => Box::new(Goal::Compatible(g)),
     <leaf:LeafGoal> => Box::new(Goal::Leaf(leaf)),
     "(" <Goal> ")",
 };

--- a/src/coherence/solve.rs
+++ b/src/coherence/solve.rs
@@ -150,7 +150,8 @@ impl DisjointSolver {
             .fold1(|goal, leaf| Goal::And(Box::new(goal), Box::new(leaf)))
             .expect("Every trait takes at least one input type")
             .quantify(QuantifierKind::Exists, binders)
-            .negate();
+            .negate()
+            .compatible();
 
         // Unless we can prove NO solution, we consider things to overlap.
         let canonical_goal = &goal.into_closed_goal();

--- a/src/fold.rs
+++ b/src/fold.rs
@@ -428,7 +428,7 @@ enum_fold!(WellFormed[] { Trait(a), Ty(a) });
 enum_fold!(FromEnv[] { Trait(a), Ty(a) });
 enum_fold!(DomainGoal[] { Holds(a), WellFormed(a), FromEnv(a), Normalize(a), UnselectedNormalize(a),
                           InScope(a), Derefs(a), IsLocal(a), IsExternal(a), IsDeeplyExternal(a),
-                          LocalImplAllowed(a) });
+                          LocalImplAllowed(a), Compatible(a), DownstreamType(a) });
 enum_fold!(LeafGoal[] { EqGoal(a), DomainGoal(a) });
 enum_fold!(Constraint[] { LifetimeEq(a, b) });
 enum_fold!(Goal[] { Quantified(qkind, subgoal), Implies(wc, subgoal), And(g1, g2), Not(g),

--- a/src/ir/debug.rs
+++ b/src/ir/debug.rs
@@ -222,6 +222,8 @@ impl Debug for DomainGoal {
                 tr.trait_id,
                 Angle(&tr.parameters[1..])
             ),
+            DomainGoal::Compatible(_) => write!(fmt, "Compatible"),
+            DomainGoal::DownstreamType(n) => write!(fmt, "DownstreamType({:?})", n),
         }
     }
 }

--- a/src/ir/lowering.rs
+++ b/src/ir/lowering.rs
@@ -1104,6 +1104,7 @@ impl<'k> LowerGoal<Env<'k>> for Goal {
                 Ok(Box::new(ir::Goal::And(g1.lower(env)?, g2.lower(env)?)))
             }
             Goal::Not(g) => Ok(Box::new(ir::Goal::Not(g.lower(env)?))),
+            Goal::Compatible(g) => Ok(Box::new(g.lower(env)?.compatible())),
             Goal::Leaf(leaf) => {
                 // A where clause can lower to multiple leaf goals; wrap these in Goal::And.
                 let leaves = leaf.lower(env)?.into_iter().map(ir::Goal::Leaf);

--- a/src/zip.rs
+++ b/src/zip.rs
@@ -69,6 +69,12 @@ impl<'a, T: ?Sized + Zip> Zip for &'a T {
     }
 }
 
+impl Zip for () {
+    fn zip_with<Z: Zipper>(_: &mut Z, _: &Self, _: &Self) -> Fallible<()> {
+        Ok(())
+    }
+}
+
 impl<T: Zip> Zip for Vec<T> {
     fn zip_with<Z: Zipper>(zipper: &mut Z, a: &Self, b: &Self) -> Fallible<()> {
         <[T] as Zip>::zip_with(zipper, a, b)
@@ -230,7 +236,9 @@ enum_zip!(DomainGoal {
     IsLocal,
     IsExternal,
     IsDeeplyExternal,
-    LocalImplAllowed
+    LocalImplAllowed,
+    Compatible,
+    DownstreamType
 });
 enum_zip!(LeafGoal { DomainGoal, EqGoal });
 enum_zip!(ProgramClause { Implies, ForAll });


### PR DESCRIPTION
This PR adds the `compatible { G }` syntax to chalk. This "activates" the compatible modality and introduces two predicates `Compatible` and `DownstreamType(T)` (where `T` is a fresh type variable).

This also wraps the queries in the overlap check with `compatible { ... }`. No other rules that use `Compatible` or `DownstreamType(T)` have been implemented yet, so this does not change the outcome of any queries.

This implementation avoids modifying the solver to support a new `compatible` goal by desugaring `compatible` into an implication during lowering. The desugaring is put into a method (similar to `negate`) so that we can conveniently use it from both the lowering code and from other code (e.g. the overlap check) which needs the compatible modality.