### PR TITLE
make rustfmt skip parser module

### DIFF
--- a/chalk-parse/src/lib.rs
+++ b/chalk-parse/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(non_modrs_mods)]
+#![feature(non_modrs_mods, tool_attributes)]
 
 #![recursion_limit = "1024"]
 
@@ -10,6 +10,7 @@ extern crate lalrpop_util;
 
 pub mod ast;
 pub mod errors;
+#[rustfmt::skip]
 mod parser;
 
 use errors::Result;


### PR DESCRIPTION
rustfmt uses many of the nursery crates as integration tests (e.g. if the library compiles/test run before formatting, check that after formatting the library still compiles/test run properly).

`chalk` revealed an issue where `rustfmt` fails to format if, for example, a module is generated by a `build.rs` and that has not been run yet. The stable `#[cfg_attr(rustfmt, rustfmt_skip)]` does not seem to be enough to work around this, but the unstable `#[rustfmt::skip]` attribute is. 

This is tracked in: https://github.com/rust-lang-nursery/rustfmt/issues/2789 but in the mean time this allows `chalk` to be part of rustfmt integration tests. It requires an extra nightly feature, but `chalk_parse` requires nightly anyways. Hopefully, by the time it does not require nightly this will be possible in stable Rust.