### PR TITLE
Replacing IsDeeplyExternal with IsFullyVisible

### DIFF
--- a/chalk-parse/src/ast.rs
+++ b/chalk-parse/src/ast.rs
@@ -257,7 +257,7 @@ pub enum DomainGoal {
     Derefs { source: Ty, target: Ty },
     IsLocal { ty: Ty },
     IsUpstream { ty: Ty },
-    IsDeeplyExternal { ty: Ty },
+    IsFullyVisible { ty: Ty },
     LocalImplAllowed { trait_ref: TraitRef },
 }
 

--- a/chalk-parse/src/parser.lalrpop
+++ b/chalk-parse/src/parser.lalrpop
@@ -302,7 +302,7 @@ DomainGoal: DomainGoal = {
 
     "IsLocal" "(" <ty:Ty> ")" => DomainGoal::IsLocal { ty },
     "IsUpstream" "(" <ty:Ty> ")" => DomainGoal::IsUpstream { ty },
-    "IsDeeplyExternal" "(" <ty:Ty> ")" => DomainGoal::IsDeeplyExternal { ty },
+    "IsFullyVisible" "(" <ty:Ty> ")" => DomainGoal::IsFullyVisible { ty },
 
     "LocalImplAllowed" "(" <trait_ref:TraitRef<":">> ")" => DomainGoal::LocalImplAllowed { trait_ref },
 };

--- a/src/fold.rs
+++ b/src/fold.rs
@@ -427,7 +427,7 @@ enum_fold!(WhereClause[] { Implemented(a), ProjectionEq(a) });
 enum_fold!(WellFormed[] { Trait(a), Ty(a) });
 enum_fold!(FromEnv[] { Trait(a), Ty(a) });
 enum_fold!(DomainGoal[] { Holds(a), WellFormed(a), FromEnv(a), Normalize(a), UnselectedNormalize(a),
-                          InScope(a), Derefs(a), IsLocal(a), IsUpstream(a), IsDeeplyExternal(a),
+                          InScope(a), Derefs(a), IsLocal(a), IsUpstream(a), IsFullyVisible(a),
                           LocalImplAllowed(a), Compatible(a), DownstreamType(a) });
 enum_fold!(LeafGoal[] { EqGoal(a), DomainGoal(a) });
 enum_fold!(Constraint[] { LifetimeEq(a, b) });

--- a/src/ir.rs
+++ b/src/ir.rs
@@ -746,23 +746,20 @@ pub enum DomainGoal {
     /// fundamental types like `Box<T>`, it is true if `T` is upstream.
     IsUpstream(Ty),
 
-    /// True if a type both external and its type parameters are recursively external
+    /// True if a type and its input types are fully visible, known types. That is, there are no
+    /// unknown type parameters anywhere in this type.
     ///
-    /// More formally, for each non-fundamental struct S<P0..Pn> that is external:
+    /// More formally, for each struct S<P0..Pn>:
     /// forall<P0..Pn> {
-    ///     IsDeeplyExternal(S<P0...Pn>) :-
-    ///         IsDeeplyExternal(P0),
+    ///     IsFullyVisible(S<P0...Pn>) :-
+    ///         IsFullyVisible(P0),
     ///         ...
-    ///         IsDeeplyExternal(Pn)
+    ///         IsFullyVisible(Pn)
     /// }
-    ///
-    /// For each fundamental struct S<P0>,
-    ///
-    /// forall<P0> { IsDeeplyExternal(S<P0>) :- IsDeeplyExternal(P0) }
     ///
     /// Note that any of these types can have lifetimes in their parameters too, but we only
     /// consider type parameters.
-    IsDeeplyExternal(Ty),
+    IsFullyVisible(Ty),
 
     /// Used to dictate when trait impls are allowed in the current (local) crate based on the
     /// orphan rules.

--- a/src/ir/debug.rs
+++ b/src/ir/debug.rs
@@ -214,7 +214,7 @@ impl Debug for DomainGoal {
             DomainGoal::Derefs(n) => write!(fmt, "Derefs({:?})", n),
             DomainGoal::IsLocal(n) => write!(fmt, "IsLocal({:?})", n),
             DomainGoal::IsUpstream(n) => write!(fmt, "IsUpstream({:?})", n),
-            DomainGoal::IsDeeplyExternal(n) => write!(fmt, "IsDeeplyExternal({:?})", n),
+            DomainGoal::IsFullyVisible(n) => write!(fmt, "IsFullyVisible({:?})", n),
             DomainGoal::LocalImplAllowed(tr) => write!(
                 fmt,
                 "LocalImplAllowed({:?}: {:?}{:?})",

--- a/src/ir/lowering.rs
+++ b/src/ir/lowering.rs
@@ -524,8 +524,8 @@ impl LowerDomainGoal for DomainGoal {
             DomainGoal::IsUpstream { ty } => vec![
                 ir::DomainGoal::IsUpstream(ty.lower(env)?)
             ],
-            DomainGoal::IsDeeplyExternal { ty } => vec![
-                ir::DomainGoal::IsDeeplyExternal(ty.lower(env)?)
+            DomainGoal::IsFullyVisible { ty } => vec![
+                ir::DomainGoal::IsFullyVisible(ty.lower(env)?)
             ],
             DomainGoal::LocalImplAllowed { trait_ref } => vec![
                 ir::DomainGoal::LocalImplAllowed(trait_ref.lower(env)?)

--- a/src/zip.rs
+++ b/src/zip.rs
@@ -235,7 +235,7 @@ enum_zip!(DomainGoal {
     Derefs,
     IsLocal,
     IsUpstream,
-    IsDeeplyExternal,
+    IsFullyVisible,
     LocalImplAllowed,
     Compatible,
     DownstreamType


### PR DESCRIPTION
This fixes a bug in the orphan check.

When @nikomatsakis first wrote their [Coherence Sketch](https://gist.github.com/nikomatsakis/d82d18fb08453074457c906f8198e3e3), there was a small mistake in one of the orphan rules listed that made it seem like each type prior to the first local type had to be **deeply external**. It turns out that the actual rule and implementation in rustc is different from that. In reality, each type prior to the first local type is only required to not contain any of the type parameters of the impl. Local or external does not matter. 

Niko came up with a new term for this "**fully visible**" which encompasses the fact that the type is not a placeholder type. We lower *all* structs with the `IsFullyVisible` predicate and then use that in `LocalImplAllowed` to get the correct, intended behaviour.

Here is the relevant code in rustc:

https://github.com/rust-lang/rust/blob/9cc3d44b935fb97f19fed4395861cbc8d6bba0e4/src/librustc/traits/coherence.rs#L382-L387