### PR TITLE
Add parsing for Compatible and DownstreamType

### DIFF
--- a/chalk-parse/src/ast.rs
+++ b/chalk-parse/src/ast.rs
@@ -259,6 +259,8 @@ pub enum DomainGoal {
     IsUpstream { ty: Ty },
     IsFullyVisible { ty: Ty },
     LocalImplAllowed { trait_ref: TraitRef },
+    Compatible,
+    DownstreamType { ty: Ty },
 }
 
 #[derive(Clone, PartialEq, Eq, Debug)]

--- a/chalk-parse/src/parser.lalrpop
+++ b/chalk-parse/src/parser.lalrpop
@@ -305,6 +305,9 @@ DomainGoal: DomainGoal = {
     "IsFullyVisible" "(" <ty:Ty> ")" => DomainGoal::IsFullyVisible { ty },
 
     "LocalImplAllowed" "(" <trait_ref:TraitRef<":">> ")" => DomainGoal::LocalImplAllowed { trait_ref },
+
+    "Compatible" => DomainGoal::Compatible,
+    "DownstreamType" "(" <ty:Ty> ")" => DomainGoal::DownstreamType { ty },
 };
 
 LeafGoal: LeafGoal = {

--- a/src/ir/lowering.rs
+++ b/src/ir/lowering.rs
@@ -530,6 +530,12 @@ impl LowerDomainGoal for DomainGoal {
             DomainGoal::LocalImplAllowed { trait_ref } => vec![
                 ir::DomainGoal::LocalImplAllowed(trait_ref.lower(env)?)
             ],
+            DomainGoal::Compatible => vec![
+                ir::DomainGoal::Compatible(())
+            ],
+            DomainGoal::DownstreamType { ty } => vec![
+                ir::DomainGoal::DownstreamType(ty.lower(env)?)
+            ],
         };
         Ok(goals)
     }


### PR DESCRIPTION
This enables you to type goals interactively that contain `Compatible` and `DownstreamType`. We don't necessarily want to do that when we're writing tests, so that's why this parsing wasn't added before.