### PR TITLE
More useful debug implementation for ProgramClause and ProgramClauseImplication

### DIFF
--- a/src/ir.rs
+++ b/src/ir.rs
@@ -959,13 +959,13 @@ impl<V: IntoIterator> Iterator for BindersIntoIterator<V> {
 /// Represents one clause of the form `consequence :- conditions` where
 /// `conditions = cond_1 && cond_2 && ...` is the conjunction of the individual
 /// conditions.
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ProgramClauseImplication {
     crate consequence: DomainGoal,
     crate conditions: Vec<Goal>,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum ProgramClause {
     Implies(ProgramClauseImplication),
     ForAll(Binders<ProgramClauseImplication>),

--- a/src/ir/debug.rs
+++ b/src/ir/debug.rs
@@ -291,6 +291,32 @@ impl<T: Debug> Debug for Binders<T> {
     }
 }
 
+impl Debug for ProgramClause {
+    fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
+        match self {
+            ProgramClause::Implies(pc) => write!(fmt, "{:?}", pc),
+            ProgramClause::ForAll(pc) => write!(fmt, "{:?}", pc),
+        }
+    }
+}
+
+impl Debug for ProgramClauseImplication {
+    fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
+        write!(fmt, "{:?}", self.consequence)?;
+
+        let conds = self.conditions.len();
+        if conds == 0 {
+            return Ok(());
+        }
+
+        write!(fmt, " :- ")?;
+        for cond in &self.conditions[..conds - 1] {
+            write!(fmt, "{:?}, ", cond)?;
+        }
+        write!(fmt, "{:?}", self.conditions[conds - 1])
+    }
+}
+
 impl Debug for Environment {
     fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
         write!(fmt, "Env({:?})", self.clauses)


### PR DESCRIPTION
This is something I did while I was debugging why some of my code wasn't working. This makes it significantly easier to read program clauses. I am open to any feedback for how to make this better. 

One thing I could do if you think it makes sense is print out the conditions of the program clause implication as a list with `[` and `]` wrapped around it (there is a method for that in `Formatter`).