### PR TITLE
Implementing support for Fundamental Traits

### DIFF
--- a/chalk-parse/src/ast.rs
+++ b/chalk-parse/src/ast.rs
@@ -55,6 +55,7 @@ pub struct TraitFlags {
     pub auto: bool,
     pub marker: bool,
     pub upstream: bool,
+    pub fundamental: bool,
     pub deref: bool,
 }
 

--- a/chalk-parse/src/parser.lalrpop
+++ b/chalk-parse/src/parser.lalrpop
@@ -58,7 +58,7 @@ StructDefn: StructDefn = {
 };
 
 TraitDefn: TraitDefn = {
-    <auto:AutoKeyword?> <marker:MarkerKeyword?> <upstream:UpstreamKeyword?> <deref:DerefLangItem?> "trait" <n:Id><p:Angle<ParameterKind>>
+    <auto:AutoKeyword?> <marker:MarkerKeyword?> <upstream:UpstreamKeyword?> <fundamental:FundamentalKeyword?> <deref:DerefLangItem?> "trait" <n:Id><p:Angle<ParameterKind>>
         <w:QuantifiedWhereClauses> "{" <a:AssocTyDefn*> "}" => TraitDefn
     {
         name: n,
@@ -69,6 +69,7 @@ TraitDefn: TraitDefn = {
             auto: auto.is_some(),
             marker: marker.is_some(),
             upstream: upstream.is_some(),
+            fundamental: fundamental.is_some(),
             deref: deref.is_some(),
         },
     }

--- a/src/ir.rs
+++ b/src/ir.rs
@@ -272,6 +272,7 @@ pub struct TraitFlags {
     crate auto: bool,
     crate marker: bool,
     crate upstream: bool,
+    crate fundamental: bool,
     pub deref: bool,
 }
 

--- a/src/ir/lowering.rs
+++ b/src/ir/lowering.rs
@@ -1056,6 +1056,7 @@ impl LowerTrait for TraitDefn {
                     auto: self.flags.auto,
                     marker: self.flags.marker,
                     upstream: self.flags.upstream,
+                    fundamental: self.flags.fundamental,
                     deref: self.flags.deref,
                 },
             })


### PR DESCRIPTION
This PR adds support for fundamental traits to chalk. This is the final, somewhat forgotten, piece of coherence which was left to the very end in case we didn't have time for it. Based on our initial discussion of how to implement it, it seems to have turned out to be a very simple and elegant change. This PR probably adds more documentation than code changes.

The documentation added to `src/rules.rs` and the test added to `src/coherence/test.rs` as part of this PR act as a great explanation of what these changes are and why they work.

I recommend reviewing this with [whitespace disabled](https://help.github.com/articles/about-comparing-branches-in-pull-requests/) so you can see the real changes.

**Friendly reminder:** Please also review my other PR updating chalk's dependencies: #166 