### PR TITLE
bump version to 0.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -82,7 +82,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "chalk"
 version = "0.1.0"
 dependencies = [
- "chalk-engine 0.6.0",
+ "chalk-engine 0.7.0",
  "chalk-macros 0.1.0",
  "chalk-parse 0.1.0",
  "diff 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -100,7 +100,7 @@ dependencies = [
 
 [[package]]
 name = "chalk-engine"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "chalk-macros 0.1.0",
  "rustc-hash 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ version = "0.1.0"
 path = "chalk-macros"
 
 [dependencies.chalk-engine]
-version = "0.6.0"
+version = "0.7.0"
 path = "chalk-engine"
 
 [workspace]

--- a/chalk-engine/Cargo.toml
+++ b/chalk-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chalk-engine"
-version = "0.6.0"
+version = "0.7.0"
 description = "Core trait engine from Chalk project"
 license = "Apache-2.0/MIT"
 authors = ["Rust Compiler Team", "Chalk developers"]


### PR DESCRIPTION
Published a 0.7.0 release. There probably haven't been any breaking changes but I'm not really sure.