### PR TITLE
distinguish bound vs inference variables

### DIFF
--- a/chalk-engine/src/hh.rs
+++ b/chalk-engine/src/hh.rs
@@ -15,7 +15,7 @@ pub enum HhGoal<C: Context> {
 
     /// Indicates something that cannot be proven to be true or false
     /// definitively. This can occur with overflow but also with
-    /// unifications of skolemized variables like `forall<X,Y> { X = Y
+    /// unifications of placeholder variables like `forall<X,Y> { X = Y
     /// }`. Of course, that statement is false, as there exist types
     /// X, Y where `X = Y` is not true. But we treat it as "cannot
     /// prove" so that `forall<X,Y> { not { X = Y } }` also winds up

--- a/chalk-ir/src/debug.rs
+++ b/chalk-ir/src/debug.rs
@@ -39,7 +39,8 @@ impl Debug for TypeName {
 impl Debug for Ty {
     fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
         match self {
-            Ty::Var(depth) => write!(fmt, "?{}", depth),
+            Ty::BoundVar(depth) => write!(fmt, "^{}", depth),
+            Ty::InferenceVar(var) => write!(fmt, "{:?}", var),
             Ty::Apply(apply) => write!(fmt, "{:?}", apply),
             Ty::Projection(proj) => write!(fmt, "{:?}", proj),
             Ty::UnselectedProjection(proj) => write!(fmt, "{:?}", proj),
@@ -47,6 +48,13 @@ impl Debug for Ty {
         }
     }
 }
+
+impl Debug for InferenceVar {
+    fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
+        write!(fmt, "?{}", self.index)
+    }
+}
+
 
 impl Debug for QuantifiedTy {
     fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
@@ -59,7 +67,8 @@ impl Debug for QuantifiedTy {
 impl Debug for Lifetime {
     fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
         match self {
-            Lifetime::Var(depth) => write!(fmt, "'?{}", depth),
+            Lifetime::BoundVar(depth) => write!(fmt, "'?{}", depth),
+            Lifetime::InferenceVar(var) => write!(fmt, "'{:?}", var),
             Lifetime::Placeholder(index) => write!(fmt, "'{:?}", index),
         }
     }

--- a/chalk-ir/src/debug.rs
+++ b/chalk-ir/src/debug.rs
@@ -67,7 +67,7 @@ impl Debug for QuantifiedTy {
 impl Debug for Lifetime {
     fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
         match self {
-            Lifetime::BoundVar(depth) => write!(fmt, "'?{}", depth),
+            Lifetime::BoundVar(depth) => write!(fmt, "'^{}", depth),
             Lifetime::InferenceVar(var) => write!(fmt, "'{:?}", var),
             Lifetime::Placeholder(index) => write!(fmt, "'{:?}", index),
         }

--- a/chalk-ir/src/debug.rs
+++ b/chalk-ir/src/debug.rs
@@ -30,7 +30,7 @@ impl Debug for TypeName {
     fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
         match self {
             TypeName::ItemId(id) => write!(fmt, "{:?}", id),
-            TypeName::ForAll(universe) => write!(fmt, "!{}_{}", universe.ui.counter, universe.idx),
+            TypeName::Placeholder(universe) => write!(fmt, "!{}_{}", universe.ui.counter, universe.idx),
             TypeName::AssociatedType(assoc_ty) => write!(fmt, "{:?}", assoc_ty),
         }
     }
@@ -60,7 +60,7 @@ impl Debug for Lifetime {
     fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
         match self {
             Lifetime::Var(depth) => write!(fmt, "'?{}", depth),
-            Lifetime::ForAll(UniversalIndex { ui, idx }) => write!(fmt, "'!{}_{}", ui.counter, idx),
+            Lifetime::Placeholder(PlaceholderIndex { ui, idx }) => write!(fmt, "'!{}_{}", ui.counter, idx),
         }
     }
 }

--- a/chalk-ir/src/debug.rs
+++ b/chalk-ir/src/debug.rs
@@ -30,7 +30,7 @@ impl Debug for TypeName {
     fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
         match self {
             TypeName::ItemId(id) => write!(fmt, "{:?}", id),
-            TypeName::Placeholder(universe) => write!(fmt, "!{}_{}", universe.ui.counter, universe.idx),
+            TypeName::Placeholder(index) => write!(fmt, "{:?}", index),
             TypeName::AssociatedType(assoc_ty) => write!(fmt, "{:?}", assoc_ty),
         }
     }
@@ -60,8 +60,15 @@ impl Debug for Lifetime {
     fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
         match self {
             Lifetime::Var(depth) => write!(fmt, "'?{}", depth),
-            Lifetime::Placeholder(PlaceholderIndex { ui, idx }) => write!(fmt, "'!{}_{}", ui.counter, idx),
+            Lifetime::Placeholder(index) => write!(fmt, "'{:?}", index),
         }
+    }
+}
+
+impl Debug for PlaceholderIndex {
+    fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
+        let PlaceholderIndex { ui, idx } = self;
+        write!(fmt, "!{}_{}", ui.counter, idx)
     }
 }
 

--- a/chalk-ir/src/fold.rs
+++ b/chalk-ir/src/fold.rs
@@ -36,16 +36,18 @@ pub use self::subst::Subst;
 /// (either existentially or universally quantified) and replace them
 /// with other types/lifetimes as appropriate.
 ///
-/// To create a folder type F, one typically does one of two things:
+/// To create a folder `F`, one never implements `Folder` directly, but instead
+/// implements one of each of these three sub-traits:
 ///
-/// - Implement `FreeVarFolder` and `DefaultPlaceholderFolder`:
-///   - This ignores universally quantified variables but allows you to
-///     replace existential variables with new values.
-/// - Implement `FreeVarFolder` and `PlaceholderFolder`:
-///   - This allows you to replace either existential or universal
-///     variables with new types/lifetimes.
-///
-/// There is no reason to implement the `Folder` trait directly.
+/// - `FreeVarFolder` -- folds `BoundVar` instances that appear free
+///   in the term being folded (use `DefaultFreeVarFolder` to
+///   ignore/forbid these altogether)
+/// - `InferenceFolder` -- folds existential `InferenceVar` instances
+///   that appear in the term being folded (use
+///   `DefaultInferenceFolder` to ignore/forbid these altogether)
+/// - `PlaceholderFolder` -- folds universal `Placeholder` instances
+///   that appear in the term being folded (use
+///   `DefaultPlaceholderFolder` to ignore/forbid these altogether)
 ///
 /// To **apply** a folder, use the `Fold::fold_with` method, like so
 ///
@@ -113,8 +115,11 @@ pub trait FreeVarFolder {
 }
 
 /// A convenience trait. If you implement this, you get an
-/// implementation of `PlaceholderFolder` for free that simply ignores
+/// implementation of `FreVarFolder` for free that simply ignores
 /// universal values (that is, it replaces them with themselves).
+///
+/// You can make it panic if a free-variable is found by overriding
+/// `forbid` to return true.
 pub trait DefaultFreeVarFolder {
     fn forbid() -> bool {
         false
@@ -168,6 +173,9 @@ pub trait PlaceholderFolder {
 /// A convenience trait. If you implement this, you get an
 /// implementation of `PlaceholderFolder` for free that simply ignores
 /// placeholder values (that is, it replaces them with themselves).
+///
+/// You can make it panic if a free-variable is found by overriding
+/// `forbid` to return true.
 pub trait DefaultPlaceholderFolder {
     fn forbid() -> bool {
         false
@@ -213,6 +221,9 @@ pub trait InferenceFolder {
 /// A convenience trait. If you implement this, you get an
 /// implementation of `InferenceFolder` for free that simply ignores
 /// inference values (that is, it replaces them with themselves).
+///
+/// You can make it panic if a free-variable is found by overriding
+/// `forbid` to return true.
 pub trait DefaultInferenceFolder {
     fn forbid() -> bool {
         false

--- a/chalk-ir/src/fold.rs
+++ b/chalk-ir/src/fold.rs
@@ -100,10 +100,10 @@ where
 /// is used when you are instanting previously bound things with some
 /// replacement.
 pub trait FreeVarFolder {
-    /// Invoked for `Ty::Var` instances that are not bound within the type being folded
+    /// Invoked for `Ty::BoundVar` instances that are not bound within the type being folded
     /// over:
     ///
-    /// - `depth` is the depth of the `Ty::Var`; this has been adjusted to account for binders
+    /// - `depth` is the depth of the `Ty::BoundVar`; this has been adjusted to account for binders
     ///   in scope.
     /// - `binders` is the number of binders in scope.
     ///
@@ -115,8 +115,8 @@ pub trait FreeVarFolder {
 }
 
 /// A convenience trait. If you implement this, you get an
-/// implementation of `FreVarFolder` for free that simply ignores
-/// universal values (that is, it replaces them with themselves).
+/// implementation of `FreeVarFolder` for free that simply ignores
+/// free values (that is, it replaces them with themselves).
 ///
 /// You can make it panic if a free-variable is found by overriding
 /// `forbid` to return true.

--- a/chalk-ir/src/fold/shift.rs
+++ b/chalk-ir/src/fold/shift.rs
@@ -1,5 +1,5 @@
 use ::*;
-use super::{DefaultTypeFolder, ExistentialFolder, Fold, IdentityPlaceholderFolder};
+use super::{DefaultTypeFolder, FreeVarFolder, Fold, IdentityPlaceholderFolder};
 
 /// Methods for converting debruijn indices to move values into or out
 /// of binders.
@@ -86,12 +86,12 @@ impl Shifter {
 
 impl DefaultTypeFolder for Shifter {}
 
-impl ExistentialFolder for Shifter {
-    fn fold_free_existential_ty(&mut self, depth: usize, binders: usize) -> Fallible<Ty> {
+impl FreeVarFolder for Shifter {
+    fn fold_free_var_ty(&mut self, depth: usize, binders: usize) -> Fallible<Ty> {
         Ok(Ty::Var(self.adjust(depth, binders)))
     }
 
-    fn fold_free_existential_lifetime(
+    fn fold_free_var_lifetime(
         &mut self,
         depth: usize,
         binders: usize,
@@ -128,12 +128,12 @@ impl DownShifter {
 
 impl DefaultTypeFolder for DownShifter {}
 
-impl ExistentialFolder for DownShifter {
-    fn fold_free_existential_ty(&mut self, depth: usize, binders: usize) -> Fallible<Ty> {
+impl FreeVarFolder for DownShifter {
+    fn fold_free_var_ty(&mut self, depth: usize, binders: usize) -> Fallible<Ty> {
         Ok(Ty::Var(self.adjust(depth, binders)?))
     }
 
-    fn fold_free_existential_lifetime(
+    fn fold_free_var_lifetime(
         &mut self,
         depth: usize,
         binders: usize,

--- a/chalk-ir/src/fold/shift.rs
+++ b/chalk-ir/src/fold/shift.rs
@@ -1,5 +1,5 @@
 use ::*;
-use super::{DefaultTypeFolder, ExistentialFolder, Fold, IdentityUniversalFolder};
+use super::{DefaultTypeFolder, ExistentialFolder, Fold, IdentityPlaceholderFolder};
 
 /// Methods for converting debruijn indices to move values into or out
 /// of binders.
@@ -100,7 +100,7 @@ impl ExistentialFolder for Shifter {
     }
 }
 
-impl IdentityUniversalFolder for Shifter {}
+impl IdentityPlaceholderFolder for Shifter {}
 
 //---------------------------------------------------------------------------
 
@@ -142,4 +142,4 @@ impl ExistentialFolder for DownShifter {
     }
 }
 
-impl IdentityUniversalFolder for DownShifter {}
+impl IdentityPlaceholderFolder for DownShifter {}

--- a/chalk-ir/src/fold/shift.rs
+++ b/chalk-ir/src/fold/shift.rs
@@ -1,5 +1,5 @@
 use ::*;
-use super::{DefaultTypeFolder, FreeVarFolder, Fold, IdentityPlaceholderFolder};
+use super::{DefaultTypeFolder, FreeVarFolder, Fold, DefaultPlaceholderFolder};
 
 /// Methods for converting debruijn indices to move values into or out
 /// of binders.
@@ -100,7 +100,7 @@ impl FreeVarFolder for Shifter {
     }
 }
 
-impl IdentityPlaceholderFolder for Shifter {}
+impl DefaultPlaceholderFolder for Shifter {}
 
 //---------------------------------------------------------------------------
 
@@ -142,4 +142,4 @@ impl FreeVarFolder for DownShifter {
     }
 }
 
-impl IdentityPlaceholderFolder for DownShifter {}
+impl DefaultPlaceholderFolder for DownShifter {}

--- a/chalk-ir/src/fold/shift.rs
+++ b/chalk-ir/src/fold/shift.rs
@@ -61,7 +61,7 @@ pub trait Shift: Fold {
     fn shifted_out(&self, adjustment: usize) -> Fallible<Self::Result>;
 }
 
-impl<T: Fold> Shift for T {
+impl<T: Fold + Eq> Shift for T {
     fn shifted_in(&self, adjustment: usize) -> T::Result {
         self.fold_with(&mut Shifter { adjustment }, 0).unwrap()
     }

--- a/chalk-ir/src/fold/subst.rs
+++ b/chalk-ir/src/fold/subst.rs
@@ -28,7 +28,7 @@ impl<'b> DefaultTypeFolder for Subst<'b> {}
 impl<'b> FreeVarFolder for Subst<'b> {
     fn fold_free_var_ty(&mut self, depth: usize, binders: usize) -> Fallible<Ty> {
         if depth >= self.parameters.len() {
-            Ok(Ty::Var(depth - self.parameters.len() + binders))
+            Ok(Ty::BoundVar(depth - self.parameters.len() + binders))
         } else {
             match self.parameters[depth] {
                 ParameterKind::Ty(ref t) => Ok(t.shifted_in(binders)),
@@ -43,7 +43,7 @@ impl<'b> FreeVarFolder for Subst<'b> {
         binders: usize,
     ) -> Fallible<Lifetime> {
         if depth >= self.parameters.len() {
-            Ok(Lifetime::Var(depth - self.parameters.len() + binders))
+            Ok(Lifetime::BoundVar(depth - self.parameters.len() + binders))
         } else {
             match self.parameters[depth] {
                 ParameterKind::Lifetime(ref l) => Ok(l.shifted_in(binders)),
@@ -54,3 +54,5 @@ impl<'b> FreeVarFolder for Subst<'b> {
 }
 
 impl<'b> DefaultPlaceholderFolder for Subst<'b> {}
+
+impl<'b> DefaultInferenceFolder for Subst<'b> {}

--- a/chalk-ir/src/fold/subst.rs
+++ b/chalk-ir/src/fold/subst.rs
@@ -53,4 +53,4 @@ impl<'b> FreeVarFolder for Subst<'b> {
     }
 }
 
-impl<'b> IdentityPlaceholderFolder for Subst<'b> {}
+impl<'b> DefaultPlaceholderFolder for Subst<'b> {}

--- a/chalk-ir/src/fold/subst.rs
+++ b/chalk-ir/src/fold/subst.rs
@@ -25,8 +25,8 @@ impl QuantifiedTy {
 
 impl<'b> DefaultTypeFolder for Subst<'b> {}
 
-impl<'b> ExistentialFolder for Subst<'b> {
-    fn fold_free_existential_ty(&mut self, depth: usize, binders: usize) -> Fallible<Ty> {
+impl<'b> FreeVarFolder for Subst<'b> {
+    fn fold_free_var_ty(&mut self, depth: usize, binders: usize) -> Fallible<Ty> {
         if depth >= self.parameters.len() {
             Ok(Ty::Var(depth - self.parameters.len() + binders))
         } else {
@@ -37,7 +37,7 @@ impl<'b> ExistentialFolder for Subst<'b> {
         }
     }
 
-    fn fold_free_existential_lifetime(
+    fn fold_free_var_lifetime(
         &mut self,
         depth: usize,
         binders: usize,

--- a/chalk-ir/src/fold/subst.rs
+++ b/chalk-ir/src/fold/subst.rs
@@ -53,4 +53,4 @@ impl<'b> ExistentialFolder for Subst<'b> {
     }
 }
 
-impl<'b> IdentityUniversalFolder for Subst<'b> {}
+impl<'b> IdentityPlaceholderFolder for Subst<'b> {}

--- a/chalk-ir/src/lib.rs
+++ b/chalk-ir/src/lib.rs
@@ -3,10 +3,12 @@
 #![feature(crate_in_paths)]
 #![feature(specialization)]
 
-use chalk_engine::fallible::*;
 use cast::Cast;
+use chalk_engine::fallible::*;
 use fold::shift::Shift;
-use fold::{DefaultInferenceFolder, DefaultTypeFolder, FreeVarFolder, Fold, DefaultPlaceholderFolder};
+use fold::{
+    DefaultInferenceFolder, DefaultPlaceholderFolder, DefaultTypeFolder, Fold, FreeVarFolder,
+};
 use lalrpop_intern::InternedString;
 use std::collections::BTreeSet;
 use std::iter;
@@ -197,7 +199,7 @@ impl Ty {
 
 #[derive(Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct InferenceVar {
-    index: u32
+    index: u32,
 }
 
 impl From<u32> for InferenceVar {
@@ -940,11 +942,7 @@ impl<'a> FreeVarFolder for &'a Substitution {
         Ok(ty.shifted_in(binders))
     }
 
-    fn fold_free_var_lifetime(
-        &mut self,
-        depth: usize,
-        binders: usize,
-    ) -> Fallible<Lifetime> {
+    fn fold_free_var_lifetime(&mut self, depth: usize, binders: usize) -> Fallible<Lifetime> {
         let l = &self.parameters[depth];
         let l = l.assert_lifetime_ref();
         Ok(l.shifted_in(binders))

--- a/chalk-ir/src/lib.rs
+++ b/chalk-ir/src/lib.rs
@@ -195,6 +195,13 @@ impl Ty {
             _ => false,
         }
     }
+
+    /// True if this type contains "bound" types/lifetimes, and hence
+    /// needs to be shifted across binders. This is a very inefficient
+    /// check, intended only for debug assertions, because I am lazy.
+    pub fn needs_shift(&self) -> bool {
+        *self != self.shifted_in(1)
+    }
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
@@ -245,6 +252,16 @@ impl Lifetime {
             Some(depth)
         } else {
             None
+        }
+    }
+
+    /// True if this lifetime is a "bound" lifetime, and hence
+    /// needs to be shifted across binders. Meant for debug assertions.
+    pub fn needs_shift(&self) -> bool {
+        match self {
+            Lifetime::BoundVar(_) => true,
+            Lifetime::InferenceVar(_) => false,
+            Lifetime::Placeholder(_) => false,
         }
     }
 }

--- a/chalk-ir/src/lib.rs
+++ b/chalk-ir/src/lib.rs
@@ -6,7 +6,7 @@
 use chalk_engine::fallible::*;
 use cast::Cast;
 use fold::shift::Shift;
-use fold::{DefaultTypeFolder, FreeVarFolder, Fold, DefaultPlaceholderFolder};
+use fold::{DefaultInferenceFolder, DefaultTypeFolder, FreeVarFolder, Fold, DefaultPlaceholderFolder};
 use lalrpop_intern::InternedString;
 use std::collections::BTreeSet;
 use std::iter;
@@ -930,6 +930,12 @@ impl Substitution {
 }
 
 impl<'a> DefaultTypeFolder for &'a Substitution {}
+
+impl<'a> DefaultInferenceFolder for &'a Substitution {
+    fn forbid() -> bool {
+        true
+    }
+}
 
 impl<'a> FreeVarFolder for &'a Substitution {
     fn fold_free_var_ty(&mut self, depth: usize, binders: usize) -> Fallible<Ty> {

--- a/chalk-ir/src/lib.rs
+++ b/chalk-ir/src/lib.rs
@@ -6,7 +6,7 @@
 use chalk_engine::fallible::*;
 use cast::Cast;
 use fold::shift::Shift;
-use fold::{DefaultTypeFolder, ExistentialFolder, Fold, IdentityPlaceholderFolder};
+use fold::{DefaultTypeFolder, FreeVarFolder, Fold, IdentityPlaceholderFolder};
 use lalrpop_intern::InternedString;
 use std::collections::BTreeSet;
 use std::iter;
@@ -882,14 +882,14 @@ impl Substitution {
 
 impl<'a> DefaultTypeFolder for &'a Substitution {}
 
-impl<'a> ExistentialFolder for &'a Substitution {
-    fn fold_free_existential_ty(&mut self, depth: usize, binders: usize) -> Fallible<Ty> {
+impl<'a> FreeVarFolder for &'a Substitution {
+    fn fold_free_var_ty(&mut self, depth: usize, binders: usize) -> Fallible<Ty> {
         let ty = &self.parameters[depth];
         let ty = ty.assert_ty_ref();
         Ok(ty.shifted_in(binders))
     }
 
-    fn fold_free_existential_lifetime(
+    fn fold_free_var_lifetime(
         &mut self,
         depth: usize,
         binders: usize,

--- a/chalk-ir/src/lib.rs
+++ b/chalk-ir/src/lib.rs
@@ -931,11 +931,7 @@ impl Substitution {
 
 impl<'a> DefaultTypeFolder for &'a Substitution {}
 
-impl<'a> DefaultInferenceFolder for &'a Substitution {
-    fn forbid() -> bool {
-        true
-    }
-}
+impl<'a> DefaultInferenceFolder for &'a Substitution {}
 
 impl<'a> FreeVarFolder for &'a Substitution {
     fn fold_free_var_ty(&mut self, depth: usize, binders: usize) -> Fallible<Ty> {

--- a/chalk-ir/src/lib.rs
+++ b/chalk-ir/src/lib.rs
@@ -6,7 +6,7 @@
 use chalk_engine::fallible::*;
 use cast::Cast;
 use fold::shift::Shift;
-use fold::{DefaultTypeFolder, FreeVarFolder, Fold, IdentityPlaceholderFolder};
+use fold::{DefaultTypeFolder, FreeVarFolder, Fold, DefaultPlaceholderFolder};
 use lalrpop_intern::InternedString;
 use std::collections::BTreeSet;
 use std::iter;
@@ -900,7 +900,7 @@ impl<'a> FreeVarFolder for &'a Substitution {
     }
 }
 
-impl<'a> IdentityPlaceholderFolder for &'a Substitution {}
+impl<'a> DefaultPlaceholderFolder for &'a Substitution {}
 
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ConstrainedSubst {

--- a/chalk-ir/src/lib.rs
+++ b/chalk-ir/src/lib.rs
@@ -1,6 +1,4 @@
-#![feature(non_modrs_mods)]
 #![feature(crate_visibility_modifier)]
-#![feature(crate_in_paths)]
 #![feature(specialization)]
 
 use cast::Cast;

--- a/chalk-ir/src/macros.rs
+++ b/chalk-ir/src/macros.rs
@@ -23,8 +23,12 @@ macro_rules! ty {
         })
     };
 
-    (var $b:expr) => {
-        $crate::Ty::Var($b)
+    (infer $b:expr) => {
+        $crate::Ty::InferenceVar($crate::InferenceVar::from($b))
+    };
+
+    (bound $b:expr) => {
+        $crate::Ty::BoundVar($b)
     };
 
     (expr $b:expr) => {
@@ -49,8 +53,12 @@ macro_rules! arg {
 
 #[macro_export]
 macro_rules! lifetime {
-    (var $b:expr) => {
-        $crate::Lifetime::Var($b)
+    (infer $b:expr) => {
+        $crate::Lifetime::InferenceVar($crate::InferenceVar::from($b))
+    };
+
+    (bound $b:expr) => {
+        $crate::Lifetime::BoundVar($b)
     };
 
     (placeholder $b:expr) => {

--- a/chalk-ir/src/macros.rs
+++ b/chalk-ir/src/macros.rs
@@ -53,8 +53,8 @@ macro_rules! lifetime {
         $crate::Lifetime::Var($b)
     };
 
-    (skol $b:expr) => {
-        $crate::Lifetime::ForAll(UniversalIndex { ui: UniverseIndex { counter: $b }, idx: 0})
+    (placeholder $b:expr) => {
+        $crate::Lifetime::Placeholder(PlaceholderIndex { ui: UniverseIndex { counter: $b }, idx: 0})
     };
 
     (expr $b:expr) => {
@@ -69,8 +69,8 @@ macro_rules! lifetime {
 #[macro_export]
 macro_rules! ty_name {
     ((item $n:expr)) => { $crate::TypeName::ItemId(ItemId { index: $n }) };
-    ((skol $n:expr)) => { $crate::TypeName::ForAll(
-                            UniversalIndex {
+    ((placeholder $n:expr)) => { $crate::TypeName::Placeholder(
+                            PlaceholderIndex {
                                 ui: UniverseIndex { counter: $n },
                                 idx: 0,
                             })

--- a/chalk-solve/src/infer.rs
+++ b/chalk-solve/src/infer.rs
@@ -61,21 +61,7 @@ impl InferenceTable {
         }
 
         let subst = table.fresh_subst(&canonical.binders);
-
-        // Pointless micro-optimization: The fully correct way to
-        // instantiate `value` is to substitute `subst` like so:
-        //
-        //     let value = canonical.substitute(&subst);
-        //
-        // However, because (a) this is a canonical value, and hence
-        // contains no free variables except for those bound in the
-        // canonical binders and (b) we just create the inference
-        // table, and we created all of its variables from those same
-        // binders, we know that this substitution will have the form
-        // `?0 := ?0` and so forth.  So we can just "clone" the
-        // canonical value rather than actually substituting.
-        assert!(subst.is_identity_subst());
-        let value = canonical.value.clone();
+        let value = canonical.value.fold_with(&mut &subst, 0).unwrap();
 
         (table, subst, value)
     }

--- a/chalk-solve/src/infer.rs
+++ b/chalk-solve/src/infer.rs
@@ -170,7 +170,7 @@ impl InferenceTable {
                 let v1 = self.probe_lifetime_var(InferenceVariable::from_depth(v - binders))?;
                 Some(v1.shifted_in(binders))
             }
-            Lifetime::ForAll(_) => None,
+            Lifetime::Placeholder(_) => None,
         }
     }
 

--- a/chalk-solve/src/infer/canonicalize.rs
+++ b/chalk-solve/src/infer/canonicalize.rs
@@ -1,5 +1,5 @@
 use chalk_engine::fallible::*;
-use chalk_ir::fold::{DefaultTypeFolder, ExistentialFolder, Fold, UniversalFolder};
+use chalk_ir::fold::{DefaultTypeFolder, ExistentialFolder, Fold, PlaceholderFolder};
 use chalk_ir::fold::shift::Shift;
 use chalk_ir::*;
 use std::cmp::max;
@@ -90,15 +90,15 @@ impl<'q> Canonicalizer<'q> {
 
 impl<'q> DefaultTypeFolder for Canonicalizer<'q> {}
 
-impl<'q> UniversalFolder for Canonicalizer<'q> {
-    fn fold_free_universal_ty(&mut self, universe: UniversalIndex, _binders: usize) -> Fallible<Ty> {
+impl<'q> PlaceholderFolder for Canonicalizer<'q> {
+    fn fold_free_placeholder_ty(&mut self, universe: PlaceholderIndex, _binders: usize) -> Fallible<Ty> {
         self.max_universe = max(self.max_universe, universe.ui);
         Ok(universe.to_ty())
     }
 
-    fn fold_free_universal_lifetime(
+    fn fold_free_placeholder_lifetime(
         &mut self,
-        universe: UniversalIndex,
+        universe: PlaceholderIndex,
         _binders: usize,
     ) -> Fallible<Lifetime> {
         self.max_universe = max(self.max_universe, universe.ui);

--- a/chalk-solve/src/infer/canonicalize.rs
+++ b/chalk-solve/src/infer/canonicalize.rs
@@ -1,5 +1,5 @@
 use chalk_engine::fallible::*;
-use chalk_ir::fold::{DefaultTypeFolder, ExistentialFolder, Fold, PlaceholderFolder};
+use chalk_ir::fold::{DefaultTypeFolder, FreeVarFolder, Fold, PlaceholderFolder};
 use chalk_ir::fold::shift::Shift;
 use chalk_ir::*;
 use std::cmp::max;
@@ -106,10 +106,10 @@ impl<'q> PlaceholderFolder for Canonicalizer<'q> {
     }
 }
 
-impl<'q> ExistentialFolder for Canonicalizer<'q> {
-    fn fold_free_existential_ty(&mut self, depth: usize, binders: usize) -> Fallible<Ty> {
+impl<'q> FreeVarFolder for Canonicalizer<'q> {
+    fn fold_free_var_ty(&mut self, depth: usize, binders: usize) -> Fallible<Ty> {
         debug_heading!(
-            "fold_free_existential_ty(depth={:?}, binders={:?})",
+            "fold_free_var_ty(depth={:?}, binders={:?})",
             depth,
             binders
         );
@@ -132,13 +132,13 @@ impl<'q> ExistentialFolder for Canonicalizer<'q> {
         }
     }
 
-    fn fold_free_existential_lifetime(
+    fn fold_free_var_lifetime(
         &mut self,
         depth: usize,
         binders: usize,
     ) -> Fallible<Lifetime> {
         debug_heading!(
-            "fold_free_existential_lifetime(depth={:?}, binders={:?})",
+            "fold_free_var_lifetime(depth={:?}, binders={:?})",
             depth,
             binders
         );

--- a/chalk-solve/src/infer/instantiate.rs
+++ b/chalk-solve/src/infer/instantiate.rs
@@ -174,4 +174,4 @@ impl FreeVarFolder for Instantiator {
     }
 }
 
-impl IdentityPlaceholderFolder for Instantiator {}
+impl DefaultPlaceholderFolder for Instantiator {}

--- a/chalk-solve/src/infer/instantiate.rs
+++ b/chalk-solve/src/infer/instantiate.rs
@@ -157,7 +157,7 @@ impl FreeVarFolder for Instantiator {
         if depth < self.vars.len() {
             Ok(self.vars[depth].assert_ty_ref().shifted_in(binders))
         } else {
-            Ok(Ty::Var(depth + binders - self.vars.len())) // see comment above
+            Ok(Ty::BoundVar(depth + binders - self.vars.len())) // see comment above
         }
     }
 
@@ -169,9 +169,15 @@ impl FreeVarFolder for Instantiator {
         if depth < self.vars.len() {
             Ok(self.vars[depth].assert_lifetime_ref().shifted_in(binders))
         } else {
-            Ok(Lifetime::Var(depth + binders - self.vars.len())) // see comment above
+            Ok(Lifetime::BoundVar(depth + binders - self.vars.len())) // see comment above
         }
     }
 }
 
 impl DefaultPlaceholderFolder for Instantiator {}
+
+impl DefaultInferenceFolder for Instantiator {
+    fn forbid() -> bool {
+        true
+    }
+}

--- a/chalk-solve/src/infer/instantiate.rs
+++ b/chalk-solve/src/infer/instantiate.rs
@@ -1,39 +1,9 @@
-use chalk_engine::fallible::*;
 use chalk_ir::fold::*;
 use std::fmt::Debug;
 
 use super::*;
 
 impl InferenceTable {
-    /// Create a instance of `arg` where each variable is replaced with
-    /// a fresh inference variable of suitable kind.
-    fn instantiate<U, T>(&mut self, universes: U, arg: &T) -> T::Result
-    where
-        T: Fold + Debug,
-        U: IntoIterator<Item = ParameterKind<UniverseIndex>>,
-    {
-        debug!("instantiate(arg={:?})", arg);
-        let vars: Vec<_> = universes
-            .into_iter()
-            .map(|param_kind| self.parameter_kind_to_parameter(param_kind))
-            .collect();
-        debug!("instantiate: vars={:?}", vars);
-        let mut instantiator = Instantiator { vars };
-        arg.fold_with(&mut instantiator, 0).expect("")
-    }
-
-    fn parameter_kind_to_parameter(
-        &mut self,
-        param_kind: ParameterKind<UniverseIndex>,
-    ) -> Parameter {
-        match param_kind {
-            ParameterKind::Ty(ui) => ParameterKind::Ty(self.new_variable(ui).to_ty()),
-            ParameterKind::Lifetime(ui) => {
-                ParameterKind::Lifetime(self.new_variable(ui).to_lifetime())
-            }
-        }
-    }
-
     /// Given the binders from a canonicalized value C, returns a
     /// substitution S mapping each free variable in C to a fresh
     /// inference variable. This substitution can then be applied to
@@ -56,7 +26,8 @@ impl InferenceTable {
     where
         T: Fold + Debug,
     {
-        self.instantiate(bound.binders.iter().cloned(), &bound.value)
+        let subst = self.fresh_subst(&bound.binders);
+        bound.value.fold_with(&mut &subst, 0).unwrap()
     }
 
     /// Instantiates `arg` with fresh existential variables in the
@@ -74,7 +45,9 @@ impl InferenceTable {
         T: Fold,
         U: IntoIterator<Item = ParameterKind<()>>,
     {
-        self.instantiate(binders.into_iter().map(|pk| pk.map(|_| universe)), arg)
+        let binders: Vec<_> = binders.into_iter().map(|pk| pk.map(|()| universe)).collect();
+        let subst = self.fresh_subst(&binders);
+        arg.fold_with(&mut &subst, 0).unwrap()
     }
 
     /// Variant on `instantiate_in` that takes a `Binders<T>`.
@@ -138,46 +111,5 @@ impl<'a, T> BindersAndValue for (&'a Vec<ParameterKind<()>>, &'a T) {
 
     fn split(&self) -> (&[ParameterKind<()>], &Self::Output) {
         (&self.0, &self.1)
-    }
-}
-
-struct Instantiator {
-    vars: Vec<Parameter>,
-}
-
-impl DefaultTypeFolder for Instantiator {}
-
-/// When we encounter a free variable (of any kind) with index
-/// `i`, we want to map anything in the first N binders to
-/// `self.vars[i]`. Everything else stays intact, but we have to
-/// subtract `self.vars.len()` to account for the binders we are
-/// instantiating.
-impl FreeVarFolder for Instantiator {
-    fn fold_free_var_ty(&mut self, depth: usize, binders: usize) -> Fallible<Ty> {
-        if depth < self.vars.len() {
-            Ok(self.vars[depth].assert_ty_ref().shifted_in(binders))
-        } else {
-            Ok(Ty::BoundVar(depth + binders - self.vars.len())) // see comment above
-        }
-    }
-
-    fn fold_free_var_lifetime(
-        &mut self,
-        depth: usize,
-        binders: usize,
-    ) -> Fallible<Lifetime> {
-        if depth < self.vars.len() {
-            Ok(self.vars[depth].assert_lifetime_ref().shifted_in(binders))
-        } else {
-            Ok(Lifetime::BoundVar(depth + binders - self.vars.len())) // see comment above
-        }
-    }
-}
-
-impl DefaultPlaceholderFolder for Instantiator {}
-
-impl DefaultInferenceFolder for Instantiator {
-    fn forbid() -> bool {
-        true
     }
 }

--- a/chalk-solve/src/infer/instantiate.rs
+++ b/chalk-solve/src/infer/instantiate.rs
@@ -152,8 +152,8 @@ impl DefaultTypeFolder for Instantiator {}
 /// `self.vars[i]`. Everything else stays intact, but we have to
 /// subtract `self.vars.len()` to account for the binders we are
 /// instantiating.
-impl ExistentialFolder for Instantiator {
-    fn fold_free_existential_ty(&mut self, depth: usize, binders: usize) -> Fallible<Ty> {
+impl FreeVarFolder for Instantiator {
+    fn fold_free_var_ty(&mut self, depth: usize, binders: usize) -> Fallible<Ty> {
         if depth < self.vars.len() {
             Ok(self.vars[depth].assert_ty_ref().shifted_in(binders))
         } else {
@@ -161,7 +161,7 @@ impl ExistentialFolder for Instantiator {
         }
     }
 
-    fn fold_free_existential_lifetime(
+    fn fold_free_var_lifetime(
         &mut self,
         depth: usize,
         binders: usize,

--- a/chalk-solve/src/infer/instantiate.rs
+++ b/chalk-solve/src/infer/instantiate.rs
@@ -105,13 +105,13 @@ impl InferenceTable {
             .iter()
             .enumerate()
             .map(|(idx, pk)| {
-                let universal_idx = UniversalIndex { ui, idx };
+                let placeholder_idx = PlaceholderIndex { ui, idx };
                 match *pk {
                     ParameterKind::Lifetime(()) => {
-                        let lt = universal_idx.to_lifetime();
+                        let lt = placeholder_idx.to_lifetime();
                         ParameterKind::Lifetime(lt)
                     }
-                    ParameterKind::Ty(()) => ParameterKind::Ty(universal_idx.to_ty()),
+                    ParameterKind::Ty(()) => ParameterKind::Ty(placeholder_idx.to_ty()),
                 }
             })
             .collect();
@@ -174,4 +174,4 @@ impl ExistentialFolder for Instantiator {
     }
 }
 
-impl IdentityUniversalFolder for Instantiator {}
+impl IdentityPlaceholderFolder for Instantiator {}

--- a/chalk-solve/src/infer/invert.rs
+++ b/chalk-solve/src/infer/invert.rs
@@ -4,7 +4,7 @@ use chalk_ir::fold::shift::Shift;
 use chalk_ir::*;
 use std::collections::HashMap;
 
-use super::{InferenceTable, InferenceVariable};
+use super::{InferenceTable, EnaVariable};
 use super::canonicalize::Canonicalized;
 
 impl InferenceTable {
@@ -97,8 +97,8 @@ impl InferenceTable {
 
 struct Inverter<'q> {
     table: &'q mut InferenceTable,
-    inverted_ty: HashMap<PlaceholderIndex, InferenceVariable>,
-    inverted_lifetime: HashMap<PlaceholderIndex, InferenceVariable>,
+    inverted_ty: HashMap<PlaceholderIndex, EnaVariable>,
+    inverted_lifetime: HashMap<PlaceholderIndex, EnaVariable>,
 }
 
 impl<'q> Inverter<'q> {

--- a/chalk-solve/src/infer/invert.rs
+++ b/chalk-solve/src/infer/invert.rs
@@ -1,5 +1,5 @@
 use chalk_engine::fallible::*;
-use chalk_ir::fold::{DefaultTypeFolder, ExistentialFolder, Fold, PlaceholderFolder};
+use chalk_ir::fold::{DefaultTypeFolder, FreeVarFolder, Fold, PlaceholderFolder};
 use chalk_ir::fold::shift::Shift;
 use chalk_ir::*;
 use std::collections::HashMap;
@@ -141,12 +141,12 @@ impl<'q> PlaceholderFolder for Inverter<'q> {
     }
 }
 
-impl<'q> ExistentialFolder for Inverter<'q> {
-    fn fold_free_existential_ty(&mut self, _depth: usize, _binders: usize) -> Fallible<Ty> {
+impl<'q> FreeVarFolder for Inverter<'q> {
+    fn fold_free_var_ty(&mut self, _depth: usize, _binders: usize) -> Fallible<Ty> {
         panic!("should not be any existentials")
     }
 
-    fn fold_free_existential_lifetime(
+    fn fold_free_var_lifetime(
         &mut self,
         _depth: usize,
         _binders: usize,

--- a/chalk-solve/src/infer/normalize_deep.rs
+++ b/chalk-solve/src/infer/normalize_deep.rs
@@ -3,7 +3,7 @@ use chalk_ir::fold::{DefaultTypeFolder, FreeVarFolder, Fold, IdentityPlaceholder
 use chalk_ir::fold::shift::Shift;
 use chalk_ir::*;
 
-use super::{InferenceTable, InferenceVariable};
+use super::{InferenceTable, EnaVariable};
 
 impl InferenceTable {
     /// Given a value `value` with variables in it, replaces those variables
@@ -34,10 +34,10 @@ impl<'table> IdentityPlaceholderFolder for DeepNormalizer<'table> {}
 
 impl<'table> FreeVarFolder for DeepNormalizer<'table> {
     fn fold_free_var_ty(&mut self, depth: usize, binders: usize) -> Fallible<Ty> {
-        let var = InferenceVariable::from_depth(depth);
+        let var = EnaVariable::from_depth(depth);
         match self.table.probe_ty_var(var) {
             Some(ty) => Ok(ty.fold_with(self, 0)?.shifted_in(binders)),
-            None => Ok(InferenceVariable::from_depth(depth + binders).to_ty()),
+            None => Ok(EnaVariable::from_depth(depth + binders).to_ty()),
         }
     }
 
@@ -46,10 +46,10 @@ impl<'table> FreeVarFolder for DeepNormalizer<'table> {
         depth: usize,
         binders: usize,
     ) -> Fallible<Lifetime> {
-        let var = InferenceVariable::from_depth(depth);
+        let var = EnaVariable::from_depth(depth);
         match self.table.probe_lifetime_var(var) {
             Some(l) => Ok(l.fold_with(self, 0)?.shifted_in(binders)),
-            None => Ok(InferenceVariable::from_depth(depth + binders).to_lifetime()),
+            None => Ok(EnaVariable::from_depth(depth + binders).to_lifetime()),
         }
     }
 }

--- a/chalk-solve/src/infer/normalize_deep.rs
+++ b/chalk-solve/src/infer/normalize_deep.rs
@@ -1,5 +1,5 @@
 use chalk_engine::fallible::*;
-use chalk_ir::fold::{DefaultTypeFolder, FreeVarFolder, Fold, IdentityPlaceholderFolder};
+use chalk_ir::fold::{DefaultTypeFolder, FreeVarFolder, Fold, DefaultPlaceholderFolder};
 use chalk_ir::fold::shift::Shift;
 use chalk_ir::*;
 
@@ -30,7 +30,7 @@ struct DeepNormalizer<'table> {
 
 impl<'table> DefaultTypeFolder for DeepNormalizer<'table> {}
 
-impl<'table> IdentityPlaceholderFolder for DeepNormalizer<'table> {}
+impl<'table> DefaultPlaceholderFolder for DeepNormalizer<'table> {}
 
 impl<'table> FreeVarFolder for DeepNormalizer<'table> {
     fn fold_free_var_ty(&mut self, depth: usize, binders: usize) -> Fallible<Ty> {

--- a/chalk-solve/src/infer/normalize_deep.rs
+++ b/chalk-solve/src/infer/normalize_deep.rs
@@ -1,5 +1,5 @@
 use chalk_engine::fallible::*;
-use chalk_ir::fold::{DefaultTypeFolder, ExistentialFolder, Fold, IdentityPlaceholderFolder};
+use chalk_ir::fold::{DefaultTypeFolder, FreeVarFolder, Fold, IdentityPlaceholderFolder};
 use chalk_ir::fold::shift::Shift;
 use chalk_ir::*;
 
@@ -32,8 +32,8 @@ impl<'table> DefaultTypeFolder for DeepNormalizer<'table> {}
 
 impl<'table> IdentityPlaceholderFolder for DeepNormalizer<'table> {}
 
-impl<'table> ExistentialFolder for DeepNormalizer<'table> {
-    fn fold_free_existential_ty(&mut self, depth: usize, binders: usize) -> Fallible<Ty> {
+impl<'table> FreeVarFolder for DeepNormalizer<'table> {
+    fn fold_free_var_ty(&mut self, depth: usize, binders: usize) -> Fallible<Ty> {
         let var = InferenceVariable::from_depth(depth);
         match self.table.probe_ty_var(var) {
             Some(ty) => Ok(ty.fold_with(self, 0)?.shifted_in(binders)),
@@ -41,7 +41,7 @@ impl<'table> ExistentialFolder for DeepNormalizer<'table> {
         }
     }
 
-    fn fold_free_existential_lifetime(
+    fn fold_free_var_lifetime(
         &mut self,
         depth: usize,
         binders: usize,

--- a/chalk-solve/src/infer/normalize_deep.rs
+++ b/chalk-solve/src/infer/normalize_deep.rs
@@ -1,5 +1,5 @@
 use chalk_engine::fallible::*;
-use chalk_ir::fold::{DefaultTypeFolder, ExistentialFolder, Fold, IdentityUniversalFolder};
+use chalk_ir::fold::{DefaultTypeFolder, ExistentialFolder, Fold, IdentityPlaceholderFolder};
 use chalk_ir::fold::shift::Shift;
 use chalk_ir::*;
 
@@ -30,7 +30,7 @@ struct DeepNormalizer<'table> {
 
 impl<'table> DefaultTypeFolder for DeepNormalizer<'table> {}
 
-impl<'table> IdentityUniversalFolder for DeepNormalizer<'table> {}
+impl<'table> IdentityPlaceholderFolder for DeepNormalizer<'table> {}
 
 impl<'table> ExistentialFolder for DeepNormalizer<'table> {
     fn fold_free_existential_ty(&mut self, depth: usize, binders: usize) -> Fallible<Ty> {

--- a/chalk-solve/src/infer/test.rs
+++ b/chalk-solve/src/infer/test.rs
@@ -157,7 +157,7 @@ fn quantify_simple() {
             .canonicalize(&ty!(apply (item 0) (infer 2) (infer 1) (infer 0)))
             .quantified,
         Canonical {
-            value: ty!(apply (item 0) (infer 0) (infer 1) (infer 2)),
+            value: ty!(apply (item 0) (bound 0) (bound 1) (bound 2)),
             binders: vec![
                 ParameterKind::Ty(U2),
                 ParameterKind::Ty(U1),
@@ -190,7 +190,7 @@ fn quantify_bound() {
             .canonicalize(&ty!(apply (item 0) (expr v2b) (expr v2a) (expr v1) (expr v0)))
             .quantified,
         Canonical {
-            value: ty!(apply (item 0) (apply (item 1) (infer 0) (infer 1)) (infer 2) (infer 0) (infer 1)),
+            value: ty!(apply (item 0) (apply (item 1) (bound 0) (bound 1)) (bound 2) (bound 0) (bound 1)),
             binders: vec![
                 ParameterKind::Ty(U1),
                 ParameterKind::Ty(U0),
@@ -205,7 +205,7 @@ fn quantify_ty_under_binder() {
     let mut table = make_table();
     let v0 = table.new_variable(U0);
     let v1 = table.new_variable(U0);
-    let r2 = table.new_variable(U0);
+    let _r2 = table.new_variable(U0);
 
     // Unify v0 and v1.
     let environment0 = Environment::new();
@@ -215,7 +215,8 @@ fn quantify_ty_under_binder() {
 
     // Here: the `for_all` introduces 3 binders, so in the result,
     // `(bound 3)` references the first canonicalized inference
-    // variable.
+    // variable. -- note that `infer 0` and `infer 1` have been
+    // unified above, as well.
     assert_eq!(
         table
             .canonicalize(

--- a/chalk-solve/src/infer/test.rs
+++ b/chalk-solve/src/infer/test.rs
@@ -1,44 +1,7 @@
-use chalk_engine::fallible::*;
-use chalk_ir::fold::*;
+#![cfg(test)]
+
 use super::*;
 use super::unify::UnificationResult;
-
-impl InferenceTable {
-    pub fn normalize<T>(&mut self, value: &T) -> T::Result
-    where
-        T: Fold,
-    {
-        value.fold_with(&mut Normalizer { table: self }, 0).unwrap()
-    }
-}
-
-struct Normalizer<'a> {
-    table: &'a mut InferenceTable,
-}
-
-impl<'q> DefaultTypeFolder for Normalizer<'q> {}
-
-impl<'q> FreeVarFolder for Normalizer<'q> {
-    fn fold_free_var_ty(&mut self, depth: usize, binders: usize) -> Fallible<Ty> {
-        assert_eq!(binders, 0);
-        let var = EnaVariable::from_depth(depth);
-        match self.table.probe_ty_var(var) {
-            Some(ty) => ty.fold_with(self, 0),
-            None => Ok(var.to_ty()),
-        }
-    }
-
-    fn fold_free_var_lifetime(
-        &mut self,
-        depth: usize,
-        binders: usize,
-    ) -> Fallible<Lifetime> {
-        assert_eq!(binders, 0);
-        Ok(EnaVariable::from_depth(depth).to_lifetime())
-    }
-}
-
-impl<'q> DefaultPlaceholderFolder for Normalizer<'q> {}
 
 #[test]
 fn infer() {
@@ -49,11 +12,11 @@ fn infer() {
     table
         .unify(&environment0, &a, &ty!(apply (item 0) (expr b)))
         .unwrap();
-    assert_eq!(table.normalize(&a), ty!(apply (item 0) (expr b)));
+    assert_eq!(table.normalize_deep(&a), ty!(apply (item 0) (expr b)));
     table
         .unify(&environment0, &b, &ty!(apply (item 1)))
         .unwrap();
-    assert_eq!(table.normalize(&a), ty!(apply (item 0) (apply (item 1))));
+    assert_eq!(table.normalize_deep(&a), ty!(apply (item 0) (apply (item 1))));
 }
 
 #[test]
@@ -79,7 +42,7 @@ fn cycle_error() {
 
     // exists(A -> A = for<'a> A)
     table
-        .unify(&environment0, &a, &ty!(for_all 1 (var 1)))
+        .unify(&environment0, &a, &ty!(for_all 1 (infer 0)))
         .unwrap_err();
 }
 
@@ -191,10 +154,10 @@ fn quantify_simple() {
 
     assert_eq!(
         table
-            .canonicalize(&ty!(apply (item 0) (var 2) (var 1) (var 0)))
+            .canonicalize(&ty!(apply (item 0) (infer 2) (infer 1) (infer 0)))
             .quantified,
         Canonical {
-            value: ty!(apply (item 0) (var 0) (var 1) (var 2)),
+            value: ty!(apply (item 0) (infer 0) (infer 1) (infer 2)),
             binders: vec![
                 ParameterKind::Ty(U2),
                 ParameterKind::Ty(U1),
@@ -227,7 +190,7 @@ fn quantify_bound() {
             .canonicalize(&ty!(apply (item 0) (expr v2b) (expr v2a) (expr v1) (expr v0)))
             .quantified,
         Canonical {
-            value: ty!(apply (item 0) (apply (item 1) (var 0) (var 1)) (var 2) (var 0) (var 1)),
+            value: ty!(apply (item 0) (apply (item 1) (infer 0) (infer 1)) (infer 2) (infer 0) (infer 1)),
             binders: vec![
                 ParameterKind::Ty(U1),
                 ParameterKind::Ty(U0),
@@ -242,7 +205,7 @@ fn quantify_ty_under_binder() {
     let mut table = make_table();
     let v0 = table.new_variable(U0);
     let v1 = table.new_variable(U0);
-    let _r0 = table.new_variable(U0);
+    let r2 = table.new_variable(U0);
 
     // Unify v0 and v1.
     let environment0 = Environment::new();
@@ -250,16 +213,17 @@ fn quantify_ty_under_binder() {
         .unify(&environment0, &v0.to_ty(), &v1.to_ty())
         .unwrap();
 
-    // Here: the `for_all` introduces 3 binders, so `(var 3)`
-    // references `v0` and `(var v4)` references `v1` above.
+    // Here: the `for_all` introduces 3 binders, so in the result,
+    // `(bound 3)` references the first canonicalized inference
+    // variable.
     assert_eq!(
         table
             .canonicalize(
-                &ty!(for_all 3 (apply (item 0) (var 1) (var 3) (var 4) (lifetime (var 3))))
+                &ty!(for_all 3 (apply (item 0) (bound 1) (infer 0) (infer 1) (lifetime (infer 2))))
             )
             .quantified,
         Canonical {
-            value: ty!(for_all 3 (apply (item 0) (var 1) (var 3) (var 3) (lifetime (var 4)))),
+            value: ty!(for_all 3 (apply (item 0) (bound 1) (bound 3) (bound 3) (lifetime (bound 4)))),
             binders: vec![ParameterKind::Ty(U0), ParameterKind::Lifetime(U0)],
         }
     );
@@ -278,7 +242,7 @@ fn lifetime_constraint_indirect() {
     // Here, we unify '?1 (the lifetime variable in universe 1) with
     // '!1.
     let t_a = ty!(apply (item 0) (lifetime (placeholder 1)));
-    let t_b = ty!(apply (item 0) (lifetime (var 1)));
+    let t_b = ty!(apply (item 0) (lifetime (infer 1)));
     let UnificationResult { goals, constraints } = table.unify(&environment0, &t_a, &t_b).unwrap();
     assert!(goals.is_empty());
     assert!(constraints.is_empty());
@@ -288,7 +252,7 @@ fn lifetime_constraint_indirect() {
     // unified with `'!1`, and `'!1` is not visible from universe 0,
     // we will replace `'!1` with a new variable `'?2` and introduce a
     // (likely unsatisfiable) constraint relating them.
-    let t_c = ty!(var 0);
+    let t_c = ty!(infer 0);
     let UnificationResult { goals, constraints } = table.unify(&environment0, &t_c, &t_b).unwrap();
     assert!(goals.is_empty());
     assert_eq!(constraints.len(), 1);

--- a/chalk-solve/src/infer/test.rs
+++ b/chalk-solve/src/infer/test.rs
@@ -38,7 +38,7 @@ impl<'q> ExistentialFolder for Normalizer<'q> {
     }
 }
 
-impl<'q> IdentityUniversalFolder for Normalizer<'q> {}
+impl<'q> IdentityPlaceholderFolder for Normalizer<'q> {}
 
 #[test]
 fn infer() {
@@ -63,7 +63,7 @@ fn universe_error() {
     let environment0 = Environment::new();
     let a = table.new_variable(U0).to_ty();
     table
-        .unify(&environment0, &a, &ty!(apply (skol 1)))
+        .unify(&environment0, &a, &ty!(apply (placeholder 1)))
         .unwrap_err();
 }
 
@@ -104,7 +104,7 @@ fn universe_error_indirect_1() {
     let a = table.new_variable(U0).to_ty();
     let b = table.new_variable(U1).to_ty();
     table
-        .unify(&environment0, &b, &ty!(apply (skol 1)))
+        .unify(&environment0, &b, &ty!(apply (placeholder 1)))
         .unwrap();
     table.unify(&environment0, &a, &b).unwrap_err();
 }
@@ -118,7 +118,7 @@ fn universe_error_indirect_2() {
     let b = table.new_variable(U1).to_ty();
     table.unify(&environment0, &a, &b).unwrap();
     table
-        .unify(&environment0, &b, &ty!(apply (skol 1)))
+        .unify(&environment0, &b, &ty!(apply (placeholder 1)))
         .unwrap_err();
 }
 
@@ -148,7 +148,7 @@ fn universe_promote_bad() {
         .unify(&environment0, &a, &ty!(apply (item 0) (expr b)))
         .unwrap();
     table
-        .unify(&environment0, &b, &ty!(apply (skol 1)))
+        .unify(&environment0, &b, &ty!(apply (placeholder 1)))
         .unwrap_err();
 }
 
@@ -277,7 +277,7 @@ fn lifetime_constraint_indirect() {
 
     // Here, we unify '?1 (the lifetime variable in universe 1) with
     // '!1.
-    let t_a = ty!(apply (item 0) (lifetime (skol 1)));
+    let t_a = ty!(apply (item 0) (lifetime (placeholder 1)));
     let t_b = ty!(apply (item 0) (lifetime (var 1)));
     let UnificationResult { goals, constraints } = table.unify(&environment0, &t_a, &t_b).unwrap();
     assert!(goals.is_empty());

--- a/chalk-solve/src/infer/test.rs
+++ b/chalk-solve/src/infer/test.rs
@@ -18,8 +18,8 @@ struct Normalizer<'a> {
 
 impl<'q> DefaultTypeFolder for Normalizer<'q> {}
 
-impl<'q> ExistentialFolder for Normalizer<'q> {
-    fn fold_free_existential_ty(&mut self, depth: usize, binders: usize) -> Fallible<Ty> {
+impl<'q> FreeVarFolder for Normalizer<'q> {
+    fn fold_free_var_ty(&mut self, depth: usize, binders: usize) -> Fallible<Ty> {
         assert_eq!(binders, 0);
         let var = InferenceVariable::from_depth(depth);
         match self.table.probe_ty_var(var) {
@@ -28,7 +28,7 @@ impl<'q> ExistentialFolder for Normalizer<'q> {
         }
     }
 
-    fn fold_free_existential_lifetime(
+    fn fold_free_var_lifetime(
         &mut self,
         depth: usize,
         binders: usize,

--- a/chalk-solve/src/infer/test.rs
+++ b/chalk-solve/src/infer/test.rs
@@ -38,7 +38,7 @@ impl<'q> FreeVarFolder for Normalizer<'q> {
     }
 }
 
-impl<'q> IdentityPlaceholderFolder for Normalizer<'q> {}
+impl<'q> DefaultPlaceholderFolder for Normalizer<'q> {}
 
 #[test]
 fn infer() {

--- a/chalk-solve/src/infer/test.rs
+++ b/chalk-solve/src/infer/test.rs
@@ -21,7 +21,7 @@ impl<'q> DefaultTypeFolder for Normalizer<'q> {}
 impl<'q> FreeVarFolder for Normalizer<'q> {
     fn fold_free_var_ty(&mut self, depth: usize, binders: usize) -> Fallible<Ty> {
         assert_eq!(binders, 0);
-        let var = InferenceVariable::from_depth(depth);
+        let var = EnaVariable::from_depth(depth);
         match self.table.probe_ty_var(var) {
             Some(ty) => ty.fold_with(self, 0),
             None => Ok(var.to_ty()),
@@ -34,7 +34,7 @@ impl<'q> FreeVarFolder for Normalizer<'q> {
         binders: usize,
     ) -> Fallible<Lifetime> {
         assert_eq!(binders, 0);
-        Ok(InferenceVariable::from_depth(depth).to_lifetime())
+        Ok(EnaVariable::from_depth(depth).to_lifetime())
     }
 }
 

--- a/chalk-solve/src/infer/ucanonicalize.rs
+++ b/chalk-solve/src/infer/ucanonicalize.rs
@@ -1,5 +1,5 @@
 use chalk_engine::fallible::*;
-use chalk_ir::fold::{DefaultTypeFolder, Fold, IdentityExistentialFolder, PlaceholderFolder};
+use chalk_ir::fold::{DefaultTypeFolder, Fold, IdentityFreeVarFolder, PlaceholderFolder};
 use chalk_ir::*;
 
 use super::InferenceTable;
@@ -235,7 +235,7 @@ impl<'q> PlaceholderFolder for UCollector<'q> {
     }
 }
 
-impl<'q> IdentityExistentialFolder for UCollector<'q> {}
+impl<'q> IdentityFreeVarFolder for UCollector<'q> {}
 
 struct UMapToCanonical<'q> {
     universes: &'q UniverseMap,
@@ -263,7 +263,7 @@ impl<'q> PlaceholderFolder for UMapToCanonical<'q> {
     }
 }
 
-impl<'q> IdentityExistentialFolder for UMapToCanonical<'q> {}
+impl<'q> IdentityFreeVarFolder for UMapToCanonical<'q> {}
 
 struct UMapFromCanonical<'q> {
     universes: &'q UniverseMap,
@@ -291,4 +291,4 @@ impl<'q> PlaceholderFolder for UMapFromCanonical<'q> {
     }
 }
 
-impl<'q> IdentityExistentialFolder for UMapFromCanonical<'q> {}
+impl<'q> IdentityFreeVarFolder for UMapFromCanonical<'q> {}

--- a/chalk-solve/src/infer/ucanonicalize.rs
+++ b/chalk-solve/src/infer/ucanonicalize.rs
@@ -1,5 +1,5 @@
 use chalk_engine::fallible::*;
-use chalk_ir::fold::{DefaultTypeFolder, Fold, IdentityFreeVarFolder, PlaceholderFolder};
+use chalk_ir::fold::{DefaultTypeFolder, Fold, DefaultFreeVarFolder, PlaceholderFolder};
 use chalk_ir::*;
 
 use super::InferenceTable;
@@ -235,7 +235,7 @@ impl<'q> PlaceholderFolder for UCollector<'q> {
     }
 }
 
-impl<'q> IdentityFreeVarFolder for UCollector<'q> {}
+impl<'q> DefaultFreeVarFolder for UCollector<'q> {}
 
 struct UMapToCanonical<'q> {
     universes: &'q UniverseMap,
@@ -263,7 +263,7 @@ impl<'q> PlaceholderFolder for UMapToCanonical<'q> {
     }
 }
 
-impl<'q> IdentityFreeVarFolder for UMapToCanonical<'q> {}
+impl<'q> DefaultFreeVarFolder for UMapToCanonical<'q> {}
 
 struct UMapFromCanonical<'q> {
     universes: &'q UniverseMap,
@@ -291,4 +291,4 @@ impl<'q> PlaceholderFolder for UMapFromCanonical<'q> {
     }
 }
 
-impl<'q> IdentityFreeVarFolder for UMapFromCanonical<'q> {}
+impl<'q> DefaultFreeVarFolder for UMapFromCanonical<'q> {}

--- a/chalk-solve/src/infer/unify.rs
+++ b/chalk-solve/src/infer/unify.rs
@@ -1,6 +1,6 @@
 use chalk_engine::fallible::*;
 use chalk_ir::cast::Cast;
-use chalk_ir::fold::{DefaultTypeFolder, ExistentialFolder, Fold, PlaceholderFolder};
+use chalk_ir::fold::{DefaultTypeFolder, FreeVarFolder, Fold, PlaceholderFolder};
 use chalk_ir::zip::{Zip, Zipper};
 use std::sync::Arc;
 
@@ -416,8 +416,8 @@ impl<'u, 't> PlaceholderFolder for OccursCheck<'u, 't> {
     }
 }
 
-impl<'u, 't> ExistentialFolder for OccursCheck<'u, 't> {
-    fn fold_free_existential_ty(&mut self, depth: usize, binders: usize) -> Fallible<Ty> {
+impl<'u, 't> FreeVarFolder for OccursCheck<'u, 't> {
+    fn fold_free_var_ty(&mut self, depth: usize, binders: usize) -> Fallible<Ty> {
         let v = InferenceVariable::from_depth(depth);
         match self.unifier.table.unify.probe_value(v) {
             // If this variable already has a value, fold over that value instead.
@@ -453,7 +453,7 @@ impl<'u, 't> ExistentialFolder for OccursCheck<'u, 't> {
         }
     }
 
-    fn fold_free_existential_lifetime(
+    fn fold_free_var_lifetime(
         &mut self,
         depth: usize,
         binders: usize,

--- a/chalk-solve/src/infer/var.rs
+++ b/chalk-solve/src/infer/var.rs
@@ -4,9 +4,11 @@ use std::cmp::min;
 use std::fmt;
 use std::u32;
 
+/// Wrapper around `chalk_ir::InferenceVar` for coherence purposes.
 /// An inference variable represents an unknown term -- either a type
-/// or a lifetime. The variable itself is just an index into the unification
-/// table; the unification table maps it to an `InferenceValue`.
+/// or a lifetime. The variable itself is just an index into the
+/// unification table; the unification table maps it to an
+/// `InferenceValue`.
 ///
 /// Inference variables can be in one of two states (represents by the variants
 /// of an `InferenceValue`):
@@ -31,37 +33,27 @@ use std::u32;
 ///     "downcast" the resulting variable using
 ///     e.g. `value.ty().unwrap()`.
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-crate struct EnaVariable {
-    index: u32,
+crate struct EnaVariable(InferenceVar);
+
+impl From<InferenceVar> for EnaVariable {
+    fn from(var: InferenceVar) -> EnaVariable {
+        EnaVariable(var)
+    }
 }
 
 impl EnaVariable {
-    /// Create an inference variable from a debruijn depth. In terms,
-    /// like the `Ty::Var` variant, we use debruijn indices to refer
-    /// to either index variables or bound variables. Presuming that
-    /// the depth D in the term is greater than the number of
-    /// enclosing binders B, then it refers to an inference variable,
-    /// and the inference variable can be created via
-    /// `EnaVariable::from_depth(D - B)`.
-    pub fn from_depth(depth: usize) -> EnaVariable {
-        assert!(depth < u32::MAX as usize);
-        EnaVariable {
-            index: depth as u32,
-        }
-    }
-
     /// Convert this inference variable into a type. When using this
     /// method, naturally you should know from context that the kind
     /// of this inference variable is a type (we can't check it).
     pub fn to_ty(self) -> Ty {
-        Ty::Var(self.index as usize)
+        self.0.to_ty()
     }
 
     /// Convert this inference variable into a lifetime. When using this
     /// method, naturally you should know from context that the kind
     /// of this inference variable is a lifetime (we can't check it).
     pub fn to_lifetime(self) -> Lifetime {
-        Lifetime::Var(self.index as usize)
+        self.0.to_lifetime()
     }
 }
 
@@ -69,11 +61,11 @@ impl UnifyKey for EnaVariable {
     type Value = InferenceValue;
 
     fn index(&self) -> u32 {
-        self.index
+        self.0.index()
     }
 
     fn from_index(u: u32) -> Self {
-        EnaVariable { index: u }
+        EnaVariable::from(InferenceVar::from(u))
     }
 
     fn tag() -> &'static str {
@@ -122,6 +114,6 @@ impl UnifyValue for InferenceValue {
 
 impl fmt::Debug for EnaVariable {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        write!(fmt, "?{}", self.index)
+        write!(fmt, "{:?}", self.0)
     }
 }

--- a/chalk-solve/src/infer/var.rs
+++ b/chalk-solve/src/infer/var.rs
@@ -31,21 +31,21 @@ use std::u32;
 ///     "downcast" the resulting variable using
 ///     e.g. `value.ty().unwrap()`.
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-crate struct InferenceVariable {
+crate struct EnaVariable {
     index: u32,
 }
 
-impl InferenceVariable {
+impl EnaVariable {
     /// Create an inference variable from a debruijn depth. In terms,
     /// like the `Ty::Var` variant, we use debruijn indices to refer
     /// to either index variables or bound variables. Presuming that
     /// the depth D in the term is greater than the number of
     /// enclosing binders B, then it refers to an inference variable,
     /// and the inference variable can be created via
-    /// `InferenceVariable::from_depth(D - B)`.
-    pub fn from_depth(depth: usize) -> InferenceVariable {
+    /// `EnaVariable::from_depth(D - B)`.
+    pub fn from_depth(depth: usize) -> EnaVariable {
         assert!(depth < u32::MAX as usize);
-        InferenceVariable {
+        EnaVariable {
             index: depth as u32,
         }
     }
@@ -65,7 +65,7 @@ impl InferenceVariable {
     }
 }
 
-impl UnifyKey for InferenceVariable {
+impl UnifyKey for EnaVariable {
     type Value = InferenceValue;
 
     fn index(&self) -> u32 {
@@ -73,17 +73,17 @@ impl UnifyKey for InferenceVariable {
     }
 
     fn from_index(u: u32) -> Self {
-        InferenceVariable { index: u }
+        EnaVariable { index: u }
     }
 
     fn tag() -> &'static str {
-        "InferenceVariable"
+        "EnaVariable"
     }
 }
 
 /// The value of an inference variable. We start out as `Unbound` with a
 /// universe index; when the inference variable is assigned a value, it becomes
-/// bound and records that value. See `InferenceVariable` for more details.
+/// bound and records that value. See `EnaVariable` for more details.
 #[derive(Clone, Debug, PartialEq, Eq)]
 crate enum InferenceValue {
     Unbound(UniverseIndex),
@@ -120,7 +120,7 @@ impl UnifyValue for InferenceValue {
     }
 }
 
-impl fmt::Debug for InferenceVariable {
+impl fmt::Debug for EnaVariable {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> Result<(), fmt::Error> {
         write!(fmt, "?{}", self.index)
     }

--- a/chalk-solve/src/lib.rs
+++ b/chalk-solve/src/lib.rs
@@ -1,5 +1,3 @@
-#![feature(non_modrs_mods)]
-#![feature(crate_in_paths)]
 #![feature(crate_visibility_modifier)]
 
 #[macro_use]

--- a/chalk-solve/src/solve/slg/implementation/aggregate.rs
+++ b/chalk-solve/src/solve/slg/implementation/aggregate.rs
@@ -46,12 +46,6 @@ impl context::AggregateOps<SlgContext> for SlgContext {
 
         // Extract answers and merge them into `subst`. Stop once we have
         // a trivial subst (or run out of answers).
-        //
-        // FIXME -- It would be nice if we could get some idea of the
-        // "shape" of future answers to know if they *might* disrupt
-        // existing substituion; the iterator interface is obviously too
-        // limited for that, but the on-demand SLG solver probably could
-        // give us that information.
         let guidance = loop {
             if subst.value.is_empty() || is_trivial(&subst) {
                 break Guidance::Unknown;

--- a/chalk-solve/src/solve/slg/implementation/aggregate.rs
+++ b/chalk-solve/src/solve/slg/implementation/aggregate.rs
@@ -320,7 +320,7 @@ impl<'infer> AntiUnifier<'infer> {
         match (l1, l2) {
             (Lifetime::Var(_), _) | (_, Lifetime::Var(_)) => self.new_lifetime_variable(),
 
-            (Lifetime::ForAll(_), Lifetime::ForAll(_)) => if l1 == l2 {
+            (Lifetime::Placeholder(_), Lifetime::Placeholder(_)) => if l1 == l2 {
                 *l1
             } else {
                 self.new_lifetime_variable()

--- a/chalk-solve/src/solve/slg/implementation/aggregate.rs
+++ b/chalk-solve/src/solve/slg/implementation/aggregate.rs
@@ -1,9 +1,9 @@
 use chalk_ir::cast::Cast;
 use chalk_ir::*;
 use crate::ext::*;
-use crate::solve::{Guidance, Solution};
-use crate::solve::slg::implementation::SubstitutionExt;
 use crate::infer::InferenceTable;
+use crate::solve::slg::implementation::SubstitutionExt;
+use crate::solve::{Guidance, Solution};
 
 use chalk_engine::context;
 use chalk_engine::SimplifiedAnswer;
@@ -57,9 +57,9 @@ impl context::AggregateOps<SlgContext> for SlgContext {
                 break Guidance::Unknown;
             }
 
-            if !simplified_answers.any_future_answer(|ref mut new_subst| {
-                new_subst.may_invalidate(&subst)
-            }) {
+            if !simplified_answers
+                .any_future_answer(|ref mut new_subst| new_subst.may_invalidate(&subst))
+            {
                 break Guidance::Definite(subst);
             }
 
@@ -129,8 +129,7 @@ fn merge_into_guidance(
                 universe,
             };
             aggr.aggregate_tys(&ty, ty1).cast()
-        })
-        .collect();
+        }).collect();
 
     let aggr_subst = Substitution {
         parameters: aggr_parameters,
@@ -150,7 +149,7 @@ fn is_trivial(subst: &Canonical<Substitution>) -> bool {
             // All types are mapped to distinct variables.  Since this
             // has been canonicalized, those will also be the first N
             // variables.
-            ParameterKind::Ty(t) => match t.var() {
+            ParameterKind::Ty(t) => match t.bound() {
                 None => false,
                 Some(depth) => depth == index,
             },
@@ -180,13 +179,15 @@ impl<'infer> AntiUnifier<'infer> {
             // overgeneralize.  So for example if we have two
             // solutions that are both `(X, X)`, we just produce `(Y,
             // Z)` in all cases.
-            (Ty::Var(_), Ty::Var(_)) => self.new_variable(),
+            (Ty::InferenceVar(_), Ty::InferenceVar(_)) => self.new_variable(),
 
             // Ugh. Aggregating two types like `for<'a> fn(&'a u32,
             // &'a u32)` and `for<'a, 'b> fn(&'a u32, &'b u32)` seems
             // kinda' hard. Don't try to be smart for now, just plop a
             // variable in there and be done with it.
-            (Ty::ForAll(_), Ty::ForAll(_)) => self.new_variable(),
+            (Ty::BoundVar(_), Ty::BoundVar(_)) | (Ty::ForAll(_), Ty::ForAll(_)) => {
+                self.new_variable()
+            }
 
             (Ty::Apply(apply1), Ty::Apply(apply2)) => {
                 self.aggregate_application_tys(apply1, apply2)
@@ -201,7 +202,8 @@ impl<'infer> AntiUnifier<'infer> {
             }
 
             // Mismatched base kinds.
-            (Ty::Var(_), _)
+            (Ty::InferenceVar(_), _)
+            | (Ty::BoundVar(_), _)
             | (Ty::ForAll(_), _)
             | (Ty::Apply(_), _)
             | (Ty::Projection(_), _)
@@ -240,8 +242,7 @@ impl<'infer> AntiUnifier<'infer> {
                     associated_ty_id,
                     parameters,
                 })
-            })
-            .unwrap_or_else(|| self.new_variable())
+            }).unwrap_or_else(|| self.new_variable())
     }
 
     fn aggregate_unselected_projection_tys(
@@ -264,8 +265,7 @@ impl<'infer> AntiUnifier<'infer> {
                     type_name,
                     parameters,
                 })
-            })
-            .unwrap_or_else(|| self.new_variable())
+            }).unwrap_or_else(|| self.new_variable())
     }
 
     fn aggregate_name_and_substs<N>(
@@ -318,7 +318,13 @@ impl<'infer> AntiUnifier<'infer> {
 
     fn aggregate_lifetimes(&mut self, l1: &Lifetime, l2: &Lifetime) -> Lifetime {
         match (l1, l2) {
-            (Lifetime::Var(_), _) | (_, Lifetime::Var(_)) => self.new_lifetime_variable(),
+            (Lifetime::InferenceVar(_), _) | (_, Lifetime::InferenceVar(_)) => {
+                self.new_lifetime_variable()
+            }
+
+            (Lifetime::BoundVar(_), _) | (_, Lifetime::BoundVar(_)) => {
+                self.new_lifetime_variable()
+            }
 
             (Lifetime::Placeholder(_), Lifetime::Placeholder(_)) => if l1 == l2 {
                 *l1
@@ -350,7 +356,7 @@ fn vec_i32_vs_vec_u32() {
         &ty!(apply (item 0) (apply (item 1))),
         &ty!(apply (item 0) (apply (item 2))),
     );
-    assert_eq!(ty!(apply (item 0) (var 0)), ty);
+    assert_eq!(ty!(apply (item 0) (infer 0)), ty);
 }
 
 /// Test the equivalent of `Vec<i32>` vs `Vec<i32>`
@@ -381,8 +387,11 @@ fn vec_x_vs_vec_y() {
     // Note that the `var 0` and `var 1` in these types would be
     // referring to canonicalized free variables, not variables in
     // `infer`.
-    let ty = anti_unifier.aggregate_tys(&ty!(apply (item 0) (var 0)), &ty!(apply (item 0) (var 1)));
+    let ty = anti_unifier.aggregate_tys(
+        &ty!(apply (item 0) (infer 0)),
+        &ty!(apply (item 0) (infer 1)),
+    );
 
     // But this `var 0` is from `infer.
-    assert_eq!(ty!(apply (item 0) (var 0)), ty);
+    assert_eq!(ty!(apply (item 0) (infer 0)), ty);
 }

--- a/chalk-solve/src/solve/slg/implementation/resolvent.rs
+++ b/chalk-solve/src/solve/slg/implementation/resolvent.rs
@@ -388,12 +388,12 @@ impl<'t> Zipper for AnswerSubstitutor<'t> {
                 self.assert_matching_vars(*answer_depth, *pending_depth)
             }
 
-            (Lifetime::ForAll(_), Lifetime::ForAll(_)) => {
+            (Lifetime::Placeholder(_), Lifetime::Placeholder(_)) => {
                 assert_eq!(answer, pending);
                 Ok(())
             }
 
-            (Lifetime::Var(_), _) | (Lifetime::ForAll(_), _) => panic!(
+            (Lifetime::Var(_), _) | (Lifetime::Placeholder(_), _) => panic!(
                 "structural mismatch between answer `{:?}` and pending goal `{:?}`",
                 answer, pending,
             ),

--- a/chalk-solve/src/solve/slg/implementation/resolvent.rs
+++ b/chalk-solve/src/solve/slg/implementation/resolvent.rs
@@ -321,7 +321,7 @@ impl<'t> AnswerSubstitutor<'t> {
 
 impl<'t> Zipper for AnswerSubstitutor<'t> {
     fn zip_tys(&mut self, answer: &Ty, pending: &Ty) -> Fallible<()> {
-        if let Some(pending) = self.table.normalize_shallow(pending, self.pending_binders) {
+        if let Some(pending) = self.table.normalize_shallow(pending) {
             return Zip::zip_with(self, answer, &pending);
         }
 
@@ -378,7 +378,7 @@ impl<'t> Zipper for AnswerSubstitutor<'t> {
     }
 
     fn zip_lifetimes(&mut self, answer: &Lifetime, pending: &Lifetime) -> Fallible<()> {
-        if let Some(pending) = self.table.normalize_lifetime(pending, self.pending_binders) {
+        if let Some(pending) = self.table.normalize_lifetime(pending) {
             return Zip::zip_with(self, answer, &pending);
         }
 

--- a/chalk-solve/src/solve/slg/test.rs
+++ b/chalk-solve/src/solve/slg/test.rs
@@ -327,7 +327,7 @@ fn only_draw_so_many_blow_up() {
         goal {
             exists<T> { T: Foo }
         } fixed 2 with max 10 {
-            "Some(Ambig(Definite(Canonical { value: [?0 := Vec<?0>], binders: [Ty(U0)] })))"
+            "Some(Ambig(Definite(Canonical { value: [?0 := Vec<^0>], binders: [Ty(U0)] })))"
         }
     }
 }

--- a/chalk-solve/src/solve/test.rs
+++ b/chalk-solve/src/solve/test.rs
@@ -954,7 +954,7 @@ fn forall_equality() {
         goal {
             // A valid equality; we get back a series of solvable
             // region constraints, since each region variable must
-            // refer to exactly one skolemized region, and they are
+            // refer to exactly one placeholder region, and they are
             // all in a valid universe to do so (universe 4).
             for<'a, 'b> Ref<'a, Ref<'b, Unit>>: Eq<for<'c, 'd> Ref<'c, Ref<'d, Unit>>>
         } yields {

--- a/chalk-solve/src/solve/truncate.rs
+++ b/chalk-solve/src/solve/truncate.rs
@@ -66,7 +66,7 @@ impl<'infer> Truncater<'infer> {
 
 impl<'infer> TypeFolder for Truncater<'infer> {
     fn fold_ty(&mut self, ty: &Ty, binders: usize) -> Fallible<Ty> {
-        if let Some(normalized_ty) = self.infer.normalize_shallow(ty, binders) {
+        if let Some(normalized_ty) = self.infer.normalize_shallow(ty) {
             return self.fold_ty(&normalized_ty, binders);
         }
 

--- a/chalk-solve/src/solve/truncate.rs
+++ b/chalk-solve/src/solve/truncate.rs
@@ -1,7 +1,7 @@
 //!
 
 use chalk_engine::fallible::*;
-use chalk_ir::fold::{self, Fold, IdentityFreeVarFolder, IdentityPlaceholderFolder, TypeFolder};
+use chalk_ir::fold::{self, Fold, DefaultFreeVarFolder, DefaultPlaceholderFolder, TypeFolder};
 use chalk_ir::fold::shift::Shift;
 use chalk_ir::*;
 use crate::infer::InferenceTable;
@@ -107,9 +107,9 @@ impl<'infer> TypeFolder for Truncater<'infer> {
     }
 }
 
-impl<'infer> IdentityFreeVarFolder for Truncater<'infer> {}
+impl<'infer> DefaultFreeVarFolder for Truncater<'infer> {}
 
-impl<'infer> IdentityPlaceholderFolder for Truncater<'infer> {}
+impl<'infer> DefaultPlaceholderFolder for Truncater<'infer> {}
 
 #[test]
 fn truncate_types() {

--- a/chalk-solve/src/solve/truncate.rs
+++ b/chalk-solve/src/solve/truncate.rs
@@ -1,7 +1,7 @@
 //!
 
 use chalk_engine::fallible::*;
-use chalk_ir::fold::{self, Fold, IdentityExistentialFolder, IdentityPlaceholderFolder, TypeFolder};
+use chalk_ir::fold::{self, Fold, IdentityFreeVarFolder, IdentityPlaceholderFolder, TypeFolder};
 use chalk_ir::fold::shift::Shift;
 use chalk_ir::*;
 use crate::infer::InferenceTable;
@@ -107,7 +107,7 @@ impl<'infer> TypeFolder for Truncater<'infer> {
     }
 }
 
-impl<'infer> IdentityExistentialFolder for Truncater<'infer> {}
+impl<'infer> IdentityFreeVarFolder for Truncater<'infer> {}
 
 impl<'infer> IdentityPlaceholderFolder for Truncater<'infer> {}
 

--- a/chalk-solve/src/solve/truncate.rs
+++ b/chalk-solve/src/solve/truncate.rs
@@ -1,7 +1,7 @@
 //!
 
 use chalk_engine::fallible::*;
-use chalk_ir::fold::{self, Fold, IdentityExistentialFolder, IdentityUniversalFolder, TypeFolder};
+use chalk_ir::fold::{self, Fold, IdentityExistentialFolder, IdentityPlaceholderFolder, TypeFolder};
 use chalk_ir::fold::shift::Shift;
 use chalk_ir::*;
 use crate::infer::InferenceTable;
@@ -109,7 +109,7 @@ impl<'infer> TypeFolder for Truncater<'infer> {
 
 impl<'infer> IdentityExistentialFolder for Truncater<'infer> {}
 
-impl<'infer> IdentityUniversalFolder for Truncater<'infer> {}
+impl<'infer> IdentityPlaceholderFolder for Truncater<'infer> {}
 
 #[test]
 fn truncate_types() {
@@ -122,7 +122,7 @@ fn truncate_types() {
                   (apply (item 0)
                    (apply (item 0)
                     (apply (item 0)
-                     (apply (skol 1))))));
+                     (apply (placeholder 1))))));
 
     // test: no truncation with size 5
     let Truncated {
@@ -147,7 +147,7 @@ fn truncate_types() {
     let _u2 = table.new_universe();
     let ty_in_u2 = ty!(apply (item 0)
                        (apply (item 0)
-                        (apply (skol 2))));
+                        (apply (placeholder 2))));
     table
         .unify(environment0, &ty_overflow, &ty_in_u2)
         .unwrap_err();
@@ -163,7 +163,7 @@ fn truncate_multiple_types() {
                   (apply (item 0)
                    (apply (item 0)
                     (apply (item 0)
-                     (apply (skol 1))))));
+                     (apply (placeholder 1))))));
 
     // test: no truncation with size 5
     let ty0_3 = vec![ty0.clone(), ty0.clone(), ty0.clone()];
@@ -216,7 +216,7 @@ fn truncate_normalizes() {
     // ty1 = Vec<Vec<T>>
     let ty1 = ty!(apply (item 0)
                   (apply (item 0)
-                   (apply (skol 1))));
+                   (apply (placeholder 1))));
 
     // test: truncating *before* unifying has no effect
     assert!(!truncate(&mut table, 3, &ty0).overflow);

--- a/chalk-solve/src/solve/truncate.rs
+++ b/chalk-solve/src/solve/truncate.rs
@@ -251,8 +251,7 @@ fn truncate_normalizes_under_binders() {
     let ty0 = ty!(for_all 1
                   (apply (item 0)
                    (apply (item 0)
-                    (infer 1))));
+                    (infer 0))));
 
-    // the index in `(infer 1)` should be adjusted to account for binders
     assert!(!truncate(&mut table, 4, &ty0).overflow);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,13 +1,10 @@
 #![recursion_limit = "1024"]
 #![cfg_attr(test, feature(test))]
-#![feature(crate_in_paths)]
 #![feature(crate_visibility_modifier)]
-#![feature(extern_prelude)]
 #![feature(in_band_lifetimes)]
 #![feature(macro_at_most_once_rep)]
 #![feature(specialization)]
 #![feature(step_trait)]
-#![feature(non_modrs_mods)]
 #![feature(underscore_imports)]
 
 extern crate chalk_parse;

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -762,7 +762,7 @@ impl AssociatedTyDatum {
         let mut clauses = vec![];
 
         // Fallback rule. The solver uses this to move between the projection
-        // and skolemized type.
+        // and placeholder type.
         //
         //    forall<Self> {
         //        ProjectionEq(<Self as Foo>::Assoc = (Foo::Assoc)<Self>).

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -40,8 +40,8 @@ impl Program {
                 .find(|d| d.trait_id == *trait_id)
                 .expect("Deref has no assoc item")
                 .id;
-            let t = || Ty::Var(0);
-            let u = || Ty::Var(1);
+            let t = || Ty::BoundVar(0);
+            let u = || Ty::BoundVar(1);
             program_clauses.push(
                 Binders {
                     binders: vec![ParameterKind::Ty(()), ParameterKind::Ty(())],
@@ -865,7 +865,7 @@ impl AssociatedTyDatum {
         // add new type parameter U
         let mut binders = binders;
         binders.push(ParameterKind::Ty(()));
-        let ty = Ty::Var(binders.len() - 1);
+        let ty = Ty::BoundVar(binders.len() - 1);
 
         // `Normalize(<T as Foo>::Assoc -> U)`
         let normalize = Normalize {

--- a/src/rules/wf.rs
+++ b/src/rules/wf.rs
@@ -88,13 +88,18 @@ impl FoldInputTypes for Ty {
 
             // Type parameters do not carry any input types (so we can sort of assume they are
             // always WF).
-            Ty::Var(..) => (),
+            Ty::BoundVar(..) => (),
 
             // Higher-kinded types such as `for<'a> fn(&'a u32)` introduce their own implied
             // bounds, and these bounds will be enforced upon calling such a function. In some
             // sense, well-formedness requirements for the input types of an HKT will be enforced
             // lazily, so no need to include them here.
             Ty::ForAll(..) => (),
+
+            Ty::InferenceVar(..) => panic!(
+                "unexpected inference variable in wf rules: {:?}",
+                self,
+            ),
         }
     }
 }

--- a/src/rust_ir.rs
+++ b/src/rust_ir.rs
@@ -319,8 +319,8 @@ impl<'a> ToParameter for (&'a ParameterKind<()>, usize) {
     fn to_parameter(&self) -> Parameter {
         let &(binder, index) = self;
         match *binder {
-            ParameterKind::Lifetime(_) => ParameterKind::Lifetime(Lifetime::Var(index)),
-            ParameterKind::Ty(_) => ParameterKind::Ty(Ty::Var(index)),
+            ParameterKind::Lifetime(_) => ParameterKind::Lifetime(Lifetime::BoundVar(index)),
+            ParameterKind::Ty(_) => ParameterKind::Ty(Ty::BoundVar(index)),
         }
     }
 }

--- a/src/rust_ir/lowering.rs
+++ b/src/rust_ir/lowering.rs
@@ -843,7 +843,7 @@ impl LowerTy for Ty {
                         parameters: vec![],
                     }))
                 }
-                NameLookup::Parameter(d) => Ok(chalk_ir::Ty::Var(d)),
+                NameLookup::Parameter(d) => Ok(chalk_ir::Ty::BoundVar(d)),
             },
 
             Ty::Apply { name, ref args } => {
@@ -924,7 +924,7 @@ impl LowerLifetime for Lifetime {
     fn lower(&self, env: &Env) -> Result<chalk_ir::Lifetime> {
         match *self {
             Lifetime::Id { name } => match env.lookup_lifetime(name)? {
-                LifetimeLookup::Parameter(d) => Ok(chalk_ir::Lifetime::Var(d)),
+                LifetimeLookup::Parameter(d) => Ok(chalk_ir::Lifetime::BoundVar(d)),
             },
         }
     }

--- a/src/rust_ir/lowering/test.rs
+++ b/src/rust_ir/lowering/test.rs
@@ -171,7 +171,7 @@ fn goal_quantifiers() {
     tls::set_current_program(&program, || {
         assert_eq!(
             format!("{:?}", goal),
-            "ForAll<type> { Exists<type> { ForAll<type> { Implemented(?0: Foo<?1, ?2>) } } }"
+            "ForAll<type> { Exists<type> { ForAll<type> { Implemented(^0: Foo<^1, ^2>) } } }"
         );
     });
 }
@@ -204,14 +204,14 @@ fn atc_accounting() {
             r#"ImplDatum {
     binders: for<type> ImplDatumBound {
         trait_ref: Positive(
-            Vec<?0> as Iterable
+            Vec<^0> as Iterable
         ),
         where_clauses: [],
         associated_ty_values: [
             AssociatedTyValue {
                 associated_ty_id: (Iterable::Iter),
                 value: for<lifetime> AssociatedTyValueBound {
-                    ty: Iter<'?0, ?1>
+                    ty: Iter<'^0, ^1>
                 }
             }
         ],
@@ -232,8 +232,8 @@ fn atc_accounting() {
             "ForAll<type> { \
                 ForAll<lifetime> { \
                     ForAll<type> { \
-                        (ProjectionEq(<?2 as Iterable>::Iter<'?1> = ?0), \
-                        Implemented(?2: Iterable)) \
+                        (ProjectionEq(<^2 as Iterable>::Iter<'^1> = ^0), \
+                        Implemented(^2: Iterable)) \
                     } \
                 } \
             }"

--- a/src/test.rs
+++ b/src/test.rs
@@ -956,7 +956,7 @@ fn forall_equality() {
         goal {
             // A valid equality; we get back a series of solvable
             // region constraints, since each region variable must
-            // refer to exactly one skolemized region, and they are
+            // refer to exactly one placeholder region, and they are
             // all in a valid universe to do so (universe 4).
             for<'a, 'b> Ref<'a, Ref<'b, Unit>>: Eq<for<'c, 'd> Ref<'c, Ref<'d, Unit>>>
         } yields {

--- a/src/test.rs
+++ b/src/test.rs
@@ -1198,8 +1198,8 @@ fn normalize_under_binder() {
             }
         } yields {
             "Unique; for<?U0> { \
-             substitution [?0 := Ref<'?0, I32>], \
-             lifetime constraints [InEnvironment { environment: Env([]), goal: '?0 == '!1_0 }] \
+             substitution [?0 := Ref<'^0, I32>], \
+             lifetime constraints [InEnvironment { environment: Env([]), goal: '^0 == '!1_0 }] \
              }"
         }
     }
@@ -1211,7 +1211,7 @@ fn unify_quantified_lifetimes() {
         program {
         }
 
-        // Check that `'a` (here, `'?0`) is not unified
+        // Check that `'a` (here, `'^0`) is not unified
         // with `'!1_0`, because they belong to incompatible
         // universes.
         goal {
@@ -1222,8 +1222,8 @@ fn unify_quantified_lifetimes() {
             }
         } yields {
             "Unique; for<?U0> { \
-             substitution [?0 := '?0], \
-             lifetime constraints [InEnvironment { environment: Env([]), goal: '?0 == '!1_0 }] \
+             substitution [?0 := '^0], \
+             lifetime constraints [InEnvironment { environment: Env([]), goal: '^0 == '!1_0 }] \
              }"
         }
 
@@ -1239,8 +1239,8 @@ fn unify_quantified_lifetimes() {
             }
         } yields {
             "Unique; for<?U0> { \
-             substitution [?0 := '?0, ?1 := '!1_0], \
-             lifetime constraints [InEnvironment { environment: Env([]), goal: '?0 == '!1_0 }] \
+             substitution [?0 := '^0, ?1 := '!1_0], \
+             lifetime constraints [InEnvironment { environment: Env([]), goal: '^0 == '!1_0 }] \
              }"
         }
     }
@@ -1264,8 +1264,8 @@ fn equality_binder() {
             }
         } yields {
             "Unique; for<?U1> { \
-                 substitution [?0 := '?0], \
-                 lifetime constraints [InEnvironment { environment: Env([]), goal: '!2_0 == '?0 }] \
+                 substitution [?0 := '^0], \
+                 lifetime constraints [InEnvironment { environment: Env([]), goal: '!2_0 == '^0 }] \
              }"
         }
     }
@@ -1288,7 +1288,7 @@ fn mixed_indices_unify() {
             }
         } yields {
             "Unique; for<?U0,?U0> { \
-                 substitution [?0 := '?0, ?1 := ?1, ?2 := ?1], \
+                 substitution [?0 := '^0, ?1 := ^1, ?2 := ^1], \
                  lifetime constraints []\
              }"
         }
@@ -1315,7 +1315,7 @@ fn mixed_indices_match_program() {
             }
         } yields {
             "Unique; for<?U0> { \
-                 substitution [?0 := '?0, ?1 := S, ?2 := S], \
+                 substitution [?0 := '^0, ?1 := S, ?2 := S], \
                  lifetime constraints [] \
              }"
         }
@@ -1345,7 +1345,7 @@ fn mixed_indices_normalize_application() {
                 }
             }
         } yields {
-            "Unique; for<?U0,?U0> { substitution [?0 := '?0, ?1 := ?1, ?2 := ?1], "
+            "Unique; for<?U0,?U0> { substitution [?0 := '^0, ?1 := ^1, ?2 := ^1], "
         }
     }
 }
@@ -1373,7 +1373,7 @@ fn mixed_indices_normalize_gat_application() {
             // Our GAT parameter <X> is mapped to ?0; all others appear left to right
             // in our Normalize(...) goal.
             "Unique; for<?U0,?U0,?U0> { \
-                substitution [?0 := ?0, ?1 := '?1, ?2 := ?2, ?3 := ?0, ?4 := ?2], "
+                substitution [?0 := ^0, ?1 := '^1, ?2 := ^2, ?3 := ^0, ?4 := ^2], "
         }
     }
 }
@@ -1449,7 +1449,7 @@ fn definite_guidance() {
                 T: Debug
             }
         } yields {
-            "Ambiguous; definite substitution for<?U0> { [?0 := Foo<?0>] }"
+            "Ambiguous; definite substitution for<?U0> { [?0 := Foo<^0>] }"
         }
     }
 }

--- a/src/test/slg.rs
+++ b/src/test/slg.rs
@@ -260,7 +260,7 @@ fn flounder() {
                 Answer {
                     subst: Canonical {
                         value: ConstrainedSubst {
-                            subst: [?0 := ?0],
+                            subst: [?0 := ^0],
                             constraints: []
                         },
                         binders: [
@@ -327,7 +327,7 @@ fn only_draw_so_many_blow_up() {
         goal {
             exists<T> { T: Foo }
         } fixed 2 with max 10 {
-            "Some(Ambig(Definite(Canonical { value: [?0 := Vec<?0>], binders: [Ty(U0)] })))"
+            "Some(Ambig(Definite(Canonical { value: [?0 := Vec<^0>], binders: [Ty(U0)] })))"
         }
     }
 }
@@ -874,7 +874,7 @@ fn cached_answers_1() {
                 Answer {
                     subst: Canonical {
                         value: ConstrainedSubst {
-                            subst: [?0 := HotSauce<?0>],
+                            subst: [?0 := HotSauce<^0>],
                             constraints: []
                         },
                         binders: [
@@ -964,7 +964,7 @@ fn cached_answers_2() {
                 Answer {
                     subst: Canonical {
                         value: ConstrainedSubst {
-                            subst: [?0 := HotSauce<?0>],
+                            subst: [?0 := HotSauce<^0>],
                             constraints: []
                         },
                         binders: [
@@ -1042,7 +1042,7 @@ fn cached_answers_3() {
                 Answer {
                     subst: Canonical {
                         value: ConstrainedSubst {
-                            subst: [?0 := HotSauce<?0>],
+                            subst: [?0 := HotSauce<^0>],
                             constraints: []
                         },
                         binders: [


### PR DESCRIPTION
This branch refactors Chalk's IR to separate *free inference variables* from *bound variables*. The goal is to generally clarify what is going on — for example, it removes the need to track binder depth during substitution and unification (I'm not sure if I got all the simplifications here, actually, maybe I missed some).

r? @scalexm 