### PR TITLE
bump chalk-engine to v0.8.0

### DIFF
--- a/chalk-engine/Cargo.toml
+++ b/chalk-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chalk-engine"
-version = "0.7.2"
+version = "0.8.0"
 description = "Core trait engine from Chalk project"
 license = "Apache-2.0/MIT"
 authors = ["Rust Compiler Team", "Chalk developers"]


### PR DESCRIPTION
cc @scalexm — will `cargo publish` once I land this 