### PR TITLE
Non modrs mods is unstable

### DIFF
--- a/chalk-engine/Cargo.toml
+++ b/chalk-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chalk-engine"
-version = "0.8.0"
+version = "0.8.1"
 description = "Core trait engine from Chalk project"
 license = "Apache-2.0/MIT"
 authors = ["Rust Compiler Team", "Chalk developers"]

--- a/chalk-engine/src/lib.rs
+++ b/chalk-engine/src/lib.rs
@@ -51,6 +51,7 @@
 
 #![feature(in_band_lifetimes)]
 #![feature(step_trait)]
+#![feature(non_modrs_mods)]
 
 #[macro_use]
 extern crate chalk_macros;

--- a/chalk-ir/src/lib.rs
+++ b/chalk-ir/src/lib.rs
@@ -1,5 +1,6 @@
 #![feature(crate_visibility_modifier)]
 #![feature(specialization)]
+#![feature(non_modrs_mods)]
 
 use cast::Cast;
 use chalk_engine::fallible::*;

--- a/chalk-macros/Cargo.toml
+++ b/chalk-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chalk-macros"
-version = "0.1.0"
+version = "0.1.1"
 description = "Macros for Chalk"
 license = "Apache-2.0/MIT"
 authors = ["Rust Compiler Team", "Chalk developers"]

--- a/chalk-solve/src/lib.rs
+++ b/chalk-solve/src/lib.rs
@@ -1,4 +1,5 @@
 #![feature(crate_visibility_modifier)]
+#![feature(non_modrs_mods)]
 
 #[macro_use]
 extern crate chalk_macros;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@
 #![feature(specialization)]
 #![feature(step_trait)]
 #![feature(underscore_imports)]
+#![feature(non_modrs_mods)]
 
 extern crate chalk_parse;
 #[macro_use]


### PR DESCRIPTION
This re-adds feature gates for crates to permit chalk-engine to build on stable, where `non_modrs_mods` has been last minute destabilized.

This needs to be merged and published for https://github.com/rust-lang/rust/issues/55404.

r? @nikomatsakis 