### PR TITLE
Build docs and deploy to gh-pages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,13 @@ script:
   - RUSTC_BOOTSTRAP=1 cargo test --all
   - RUSTC_BOOTSTRAP=1 cargo doc --document-private-items
 deploy:
-  provider: pages
-  local-dir: ./target/doc
-  skip-cleanup: true
-  github-token: $GITHUB_TOKEN
-  on:
-    branch: master
+  - provider: script
+    script: mkdir -p target/gh-pages && mv target/doc target/gh-pages/
+    on:
+      branch: master
+  - provider: pages
+    local-dir: ./target/gh-pages
+    skip-cleanup: true
+    github-token: $GITHUB_TOKEN
+    on:
+      branch: master

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,11 @@ script:
   - cd chalk-engine; RUSTC_BOOTSTRAP=1 cargo build --no-default-features
   - cd chalk-engine; RUSTC_BOOTSTRAP=1 cargo build --all-features
   - RUSTC_BOOTSTRAP=1 cargo test --all
-
+  - RUSTC_BOOTSTRAP=1 cargo doc --document-private-items
+deploy:
+  provider: pages
+  local-dir: ./target/doc
+  skip-cleanup: true
+  github-token: $GITHUB_TOKEN
+  on:
+    branch: master


### PR DESCRIPTION
This updates Travis CI to build our docs with `--document-private-items` and deploy them to the gh-pages branch. They should end up at http://rust-lang-nursery.github.io/chalk/doc.