### PR TITLE
Actually document private items

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ script:
   - cd chalk-engine && RUSTC_BOOTSTRAP=1 cargo build --no-default-features && cd ..
   - cd chalk-engine && RUSTC_BOOTSTRAP=1 cargo build --all-features && cd ..
   - RUSTC_BOOTSTRAP=1 cargo test --all
-  - RUSTC_BOOTSTRAP=1 cargo doc --document-private-items
+  - RUSTC_BOOTSTRAP=1 cargo doc --all --document-private-items
 deploy:
   - provider: script
     script: mkdir -p target/gh-pages && mv target/doc target/gh-pages/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -106,9 +106,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "chalk"
 version = "0.1.0"
 dependencies = [
- "chalk-engine 0.8.0",
+ "chalk-engine 0.8.1",
  "chalk-ir 0.1.0",
- "chalk-macros 0.1.0",
+ "chalk-macros 0.1.1",
  "chalk-parse 0.1.0",
  "chalk-solve 0.1.0",
  "diff 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -125,9 +125,9 @@ dependencies = [
 
 [[package]]
 name = "chalk-engine"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
- "chalk-macros 0.1.0",
+ "chalk-macros 0.1.1",
  "rustc-hash 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "stacker 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -136,14 +136,14 @@ dependencies = [
 name = "chalk-ir"
 version = "0.1.0"
 dependencies = [
- "chalk-engine 0.8.0",
- "chalk-macros 0.1.0",
+ "chalk-engine 0.8.1",
+ "chalk-macros 0.1.1",
  "lalrpop-intern 0.15.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "chalk-macros"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -163,9 +163,9 @@ dependencies = [
 name = "chalk-solve"
 version = "0.1.0"
 dependencies = [
- "chalk-engine 0.8.0",
+ "chalk-engine 0.8.1",
  "chalk-ir 0.1.0",
- "chalk-macros 0.1.0",
+ "chalk-macros 0.1.1",
  "chalk-parse 0.1.0",
  "ena 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/src/rust_ir.rs
+++ b/src/rust_ir.rs
@@ -198,7 +198,8 @@ crate trait IntoWhereClauses {
 impl IntoWhereClauses for InlineBound {
     type Output = WhereClause;
 
-    /// Applies the `InlineBound` to `self_ty` and lowers to a [`DomainGoal`].
+    /// Applies the `InlineBound` to `self_ty` and lowers to a
+    /// [`chalk_ir::DomainGoal`].
     ///
     /// Because an `InlineBound` does not know anything about what it's binding,
     /// you must provide that type as `self_ty`.


### PR DESCRIPTION
It seems I removed the `--all` from cargo doc at one point thinking it was unnecessary.. but apparently it interacts with `--document-private-items` for workspaces.