### PR TITLE
Fix an implied bounds bug

### DIFF
--- a/src/test.rs
+++ b/src/test.rs
@@ -2439,6 +2439,26 @@ fn higher_ranked_implied_bounds() {
 }
 
 #[test]
+fn recursive_where_clause_on_type() {
+    test! {
+        program {
+            trait Bar { }
+            trait Foo where Self: Bar { }
+
+            struct S where S: Foo { }
+
+            impl Foo for S { }
+        }
+
+        goal {
+            WellFormed(S)
+        } yields {
+            "No possible solution"
+        }
+    }
+}
+
+#[test]
 fn deref_goal() {
     test! {
         program {


### PR DESCRIPTION
r? @nikomatsakis 

Let's find some time to discuss again about this `WellFormed` / `FromEnv` duality. The proof I mentioned for soundness of the implied bounds setup did not model implied bounds from types, only those from traits. But I now understand better the `recursive_where_clause_on_type` test, how implied bounds from types and traits intertwine, and why this fix is the correct one.